### PR TITLE
Remove redundant anchor in preprocess expression

### DIFF
--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -34,7 +34,7 @@ index=0
 
 while IFS= read -r line; do
   index=$(($index + 1))
-  quoted_name="$(expr "$line" : '^ *@test  *\([^ ].*\)  *{ *$' || true)"
+  quoted_name="$(expr "$line" : ' *@test  *\([^ ].*\)  *{ *$' || true)"
 
   if [ -n "$quoted_name" ]; then
     name="$(eval echo "$quoted_name")"


### PR DESCRIPTION
Expr patterns are anchored to the beginning by default. Specifying
the carrot is undefined behavior and generates warnings on some versions, obscuring the test
output. (See attached screenshot)  The included pull request addresses this.

Documentation reference:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/expr.html

> "all patterns are anchored to the beginning of the string (that is, only sequences starting at the first character of a string are matched by the regular expression) and, therefore, it is unspecified whether '^' is a special character in that context"

For example the current expression works on CentOS 6, but generates the warnings on CentOS 5. Removing the carrot should preserve the expected behavior (without warnings) across all platforms. In this instance I have verified it fixes the problem on 5 without impacting 6.

![Screen Shot 2013-04-12 at 2 29 52 PM](https://f.cloud.github.com/assets/3771540/375332/c89b297c-a3b9-11e2-8bd4-bbf6199f2c78.png)
