### PR TITLE
report $output content when test fails

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -37,6 +37,7 @@ run() {
   set +e
   output="$("$@" 2>&1)"
   status="$?"
+  echo "$output" | sed -e 's/^/  #output#/' > "$BATS_OUT"
   IFS=$'\n' lines=($output)
   [ -z "$e" ] || set -e
 }


### PR DESCRIPTION
in some cases, its not easy to find why test failed. i saw one sollution with custom assert_equal. but its useful to have the content of $output printent out when test fails.

i'm not sure that this is the 100perc correct place, but this worked fine for me and i was able to fix my tests then.
