### PR TITLE
Print the bash command that caused the test to fail

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -165,6 +165,8 @@ bats_frame_filename() {
 
 bats_error_trap() {
   trap - debug
+  BATS_FAILED_COMMAND=$1
+  BATS_FAILED_STATUS=$2
 }
 
 bats_teardown_trap() {
@@ -193,6 +195,7 @@ bats_exit_trap() {
   if [ -z "$BATS_TEST_COMPLETED" ] || [ -z "$BATS_TEARDOWN_COMPLETED" ]; then
     echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
     bats_print_stack_trace >&3
+    echo "#   '$BATS_FAILED_COMMAND' exited with status $BATS_FAILED_STATUS" >&3
     sed -e "s/^/# /" < "$BATS_OUT" >&3
     status=1
   else
@@ -227,7 +230,7 @@ bats_perform_test() {
     BATS_TEST_COMPLETED=""
     BATS_TEARDOWN_COMPLETED=""
     trap "bats_capture_stack_trace \"\$BASH_SOURCE\" \$LINENO" debug
-    trap "bats_error_trap" err
+    trap "bats_error_trap \"\$BASH_COMMAND\" \$?" err
     trap "bats_teardown_trap" exit
     "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
     BATS_TEST_COMPLETED=1

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -46,6 +46,7 @@ fixtures bats
   [ ${lines[0]} = "1..1" ]
   [ ${lines[1]} = "not ok 1 a failing test" ]
   [ ${lines[2]} = "# (in test file $FIXTURE_ROOT/failing.bats, line 4)" ]
+  [ ${lines[3]} = "#   'false' exited with status 1" ]
 }
 
 @test "one failing and one passing test" {
@@ -54,7 +55,8 @@ fixtures bats
   [ ${lines[0]} = "1..2" ]
   [ ${lines[1]} = "not ok 1 a failing test" ]
   [ ${lines[2]} = "# (in test file $FIXTURE_ROOT/failing_and_passing.bats, line 2)" ]
-  [ ${lines[3]} = "ok 2 a passing test" ]
+  [ ${lines[3]} = "#   'false' exited with status 1" ]
+  [ ${lines[4]} = "ok 2 a passing test" ]
 }
 
 @test "failing helper function logs the test case's line number" {
@@ -120,9 +122,9 @@ fixtures bats
 @test "output is discarded for passing tests and printed for failing tests" {
   run bats "$FIXTURE_ROOT/output.bats"
   [ $status -eq 1 ]
-  [ "${lines[5]}" = "# failure stdout 1" ]
-  [ "${lines[6]}" = "# failure stdout 2" ]
-  [ "${lines[9]}" = "# failure stderr" ]
+  [ "${lines[6]}"  = "# failure stdout 1" ]
+  [ "${lines[7]}"  = "# failure stdout 2" ]
+  [ "${lines[11]}" = "# failure stderr" ]
 }
 
 @test "-c prints the number of tests" {
@@ -164,8 +166,8 @@ fixtures bats
   [ $status -eq 1 ]
   [ "${lines[1]}" = "begin 1 a failing test" ]
   [ "${lines[2]}" = "not ok 1 a failing test" ]
-  [ "${lines[4]}" = "begin 2 a passing test" ]
-  [ "${lines[5]}" = "ok 2 a passing test" ]
+  [ "${lines[5]}" = "begin 2 a passing test" ]
+  [ "${lines[6]}" = "ok 2 a passing test" ]
 }
 
 @test "pretty and tap formats" {


### PR DESCRIPTION
Includes the `$BASH_COMMAND` and exit status that caused the test failure in the pretty failure output

```
$ cat example.bats 
@test "a passing test" {
  true
}

@test "a failing test" {
  false
}

@test "another failing test" {
  [ true == false ]
}

@test "a failing test with variables" {
  X=1
  [ $X -eq 2 ]
}

$ bin/bats example.bats 
 ✓ a passing test
 ✗ a failing test
   (in test file /Users/ryansouza/p/bats/example.bats, line 6)
     'false' exited with status 1
 ✗ another failing test
   (in test file /Users/ryansouza/p/bats/example.bats, line 10)
     '[ true == false ]' exited with status 1
 ✗ a failing test with variables
   (in test file /Users/ryansouza/p/bats/example.bats, line 15)
     '[ $X -eq 2 ]' exited with status 1

4 tests, 3 failures

$ bin/bats -t example.bats 
1..4
ok 1 a passing test
not ok 2 a failing test
# (in test file /Users/ryansouza/p/bats/example.bats, line 6)
#   'false' exited with status 1
not ok 3 another failing test
# (in test file /Users/ryansouza/p/bats/example.bats, line 10)
#   '[ true == false ]' exited with status 1
not ok 4 a failing test with variables
# (in test file /Users/ryansouza/p/bats/example.bats, line 15)
#   '[ $X -eq 2 ]' exited with status 1
```

edit: rebased & updated (11/10)
