### PR TITLE
Add skip directive.

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -92,8 +92,11 @@ bats_exit_trap() {
     echo "# $BATS_TEST_FILENAME:$BATS_LINE_NUMBER" >&3
     sed -e "s/^/#    /" < "$BATS_OUT" >&3
     status=1
-  else
+  elif [ -z "$BATS_TEST_SKIPPED" ]; then
     echo "ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    status=0
+  else
+    echo "ok $BATS_TEST_NUMBER # skip $BATS_TEST_DESCRIPTION" >&3
     status=0
   fi
 
@@ -122,7 +125,16 @@ bats_perform_test() {
     fi
 
     BATS_TEST_COMPLETED=""
+    BATS_TEST_SKIPPED=""
     BATS_ERROR_LINE=""
+
+    directive="$(expr "$BATS_TEST_NAME" : '\([^_]*\)' || true)"
+    if [ "skip" = "$directive" ]; then
+      BATS_TEST_SKIPPED=1
+      BATS_TEST_COMPLETED=1
+      trap "bats_teardown_trap" exit
+    fi
+
     trap "bats_debug_trap \"\$BASH_SOURCE\" \$LINENO" debug
     trap "bats_error_trap" err
     trap "bats_teardown_trap" exit

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -2,8 +2,8 @@
 set -e
 
 encode_name() {
-  local name="$1"
-  local result="test_"
+  local result="$1_"
+  local name="$2"
 
   if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
     name="${name//_/-5f}"
@@ -34,13 +34,14 @@ index=0
 
 while IFS= read -r line; do
   index=$(($index + 1))
-  quoted_name="$(expr "$line" : ' *@test  *\([^ ].*\)  *{ *$' || true)"
+  directive="$(expr "$line" : ' *@\([test\|skip]*\) *\([^ ].*\)  *{ *$' || true)"
+  quoted_name="$(expr "$line" : ' *@[test\|skip]*  *\([^ ].*\)  *{ *$' || true)"
 
   if [ -n "$quoted_name" ]; then
     name="$(eval echo "$quoted_name")"
-    encoded_name="$(encode_name "$name")"
-    tests["${#tests[@]}"]="$encoded_name"
+    encoded_name="$(encode_name "$directive" "$name")"
     echo "${encoded_name}() { bats_test_info ${quoted_name} ${index}"
+      tests["${#tests[@]}"]="$encoded_name"
   else
     printf "%s\n" "$line"
   fi

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -110,3 +110,8 @@ fixtures bats
   run bats "$FIXTURE_ROOT/dos_line.bats"
   [ $status -eq 0 ]
 }
+
+@skip "A skipped test" {
+  run bats
+  [ $status -eq 0 ]
+}


### PR DESCRIPTION
Allows tests to be skipped.

Example:

```
@skip "A skipped test" {
  run bats
  [ $status -eq 0 ]
}
```

Outputs:

```
1..1
ok 1 # skip A skipped test
```

Thoughts?

There might be a way to make it so skip tests wouldn't cause an older version of bats to barf, but this syntax is quite simple.
