### PR TITLE
Update TAP format link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ an "X" if it fails.
 If Bats is not connected to a terminal—in other words, if you
 run it from a continuous integration system or redirect its output to
 a file—the results are displayed in human-readable, machine-parsable
-[TAP format](http://testanything.org/wiki/index.php/TAP_specification#THE_TAP_FORMAT).
+[TAP format](http://testanything.org).
 You can force TAP output from a terminal by invoking Bats with the
 `--tap` option.
 


### PR DESCRIPTION
The previous link to the TAP format wiki doesn't appear to be valid any longer. http://testanything.org redirects to a wiki page that explains a description of the format, so this seems like the best place to link to.
