### PR TITLE
Plugin system and a batsrc

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -51,10 +51,16 @@ load_plugin() {
 }
 
 load_batsrc() {
-  local batsrc_file="$HOME/.batsrc"
-  if [ -f $batsrc_file ]; then
-    source $batsrc_file
-  fi
+  local local_batsrc_file="$(echo "$BATS_TEST_DIRNAME" \
+    | grep -o '.*/test')/.batsrc"
+  local global_batsrc_file="$HOME/.batsrc"
+  local batsrc
+  for batsrc in $local_batsrc_file $global_batsrc_file; do
+    if [ -f $batsrc ]; then
+      source $batsrc
+      break
+    fi
+  done
 }
 
 run() {


### PR DESCRIPTION
Adds a load_plugin function to share functionality across projects.
For a plugin `foo` its default path would be `~/.bats/plugins/foo/foo.plugin.bats`
This file gets sourced - if people want to build more complex stuff they can use their `foo` to do it clean and they should souce the files inside of `foo.plugin.bats`.

Also adds sourcing of a `~/.batsrc` file, which is done just before execution starts in bats-exec-test. People can mess with bats their in every way they want, I for now would use it to load plugins. It's possible to override the global `.batsrc` in the home directory with a local `.batsrc`, to be placed inside the `test` directory (I guess it's a good convention to place all tests in such a directory anyway)

If you think this is something that can be useful, I'd add tests and update the readme.

Edit:
If someone wants to try it out with the very first bast plugin ever written, check here: https://github.com/LFDM/bats_matchers - just clone the repo into your `.bats/plugins` dir.
:) It's rather uneventful so far.
