### PR TITLE
Use `mktemp -d` for $BATS_TMPDIR

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -136,5 +136,7 @@ else
   formatter="cat"
 fi
 
+export BATS_TMPDIR="$(mktemp -d --tmpdir tmp.bats.XXXXX)"
+
 set -o pipefail execfail
 exec "$command" $count_flag $extended_syntax_flag "${filenames[@]}" | "$formatter"

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -238,11 +238,6 @@ bats_perform_test() {
   fi
 }
 
-if [ -z "$TMPDIR" ]; then
-  BATS_TMPDIR="/tmp"
-else
-  BATS_TMPDIR="${TMPDIR%/}"
-fi
 
 BATS_TMPNAME="$BATS_TMPDIR/bats.$$"
 BATS_PARENT_TMPNAME="$BATS_TMPDIR/bats.$PPID"


### PR DESCRIPTION
$BATS_TMPDIR should be a non-existent directory.

I have tried to leave the setup of BATS_TMPDIR in bats-exec-test, but
that did not work: the src files behaved very strange:

> …/libexec/bats-exec-test: line 266: /tmp/tmp.PJImwKcCF4/bats.16707.src: No such file or directory

This might be to some traps and/or other specialities.
Feel free to adopt it as it fits best.

Ref: https://github.com/sstephenson/rbenv/pull/562
