### PR TITLE
Safe-guard for `rm -f /*`

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -7,5 +7,7 @@ setup() {
 }
 
 teardown() {
+  # Safe guard, if $TMP might end up empty!
+  [[ -d "$TMP" ]] || { echo "FATAL: \$TMP is not a directory in teardown."; exit 1; }
   rm -f "$TMP"/*
 }


### PR DESCRIPTION
While looking at the source, I've seen this and imagined what might
happen if some test causes unsetting of $TMP, or if the setup method
would not be called for some reason.

As a sidenote, I've wondered why BATS_TMPDIR is not used here.
