### PR TITLE
Adding fail function

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -69,6 +69,11 @@ skip() {
   exit 0
 }
 
+fail() {
+  BATS_TEST_COMPLETED=1
+  exit 1
+}
+
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
   if [ -n "$BATS_EXTENDED_SYNTAX" ]; then

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -159,6 +159,14 @@ fixtures bats
   [ "${lines[2]}" = "ok 2 # skip (a reason) a skipped test with a reason" ]
 }
 
+@test "skipped test" {
+  skip "Test skipped"
+}
+
+@test "failed test" {
+  fail "Expected failure"
+}
+
 @test "extended syntax" {
   run bats-exec-test -x "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 1 ]


### PR DESCRIPTION
Hey, I would like to implement `fail` function that would fail immediately, so
I can write things like

```
blahblah || fail "Blah blah"
```

But my bash skills are not good enough. Can you help me with writing the
correct function? Currently it looks like it just skips the test.
