### PR TITLE
saving $IFS in run() not altered for code using it - fix #89

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -48,7 +48,7 @@ load() {
 }
 
 run() {
-  local e E T
+  local e E T oldIFS
   [[ ! "$-" =~ e ]] || e=1
   [[ ! "$-" =~ E ]] || E=1
   [[ ! "$-" =~ T ]] || T=1
@@ -57,10 +57,12 @@ run() {
   set +T
   output="$("$@" 2>&1)"
   status="$?"
+  oldIFS=$IFS
   IFS=$'\n' lines=($output)
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T
+  IFS=$oldIFS
 }
 
 setup() {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -37,7 +37,7 @@ fixtures bats
   run bats "$FIXTURE_ROOT/passing.bats"
   [ $status -eq 0 ]
   [ ${lines[0]} = "1..1" ]
-  [ ${lines[1]} = "ok 1 a passing test" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
 }
 
 @test "summary passing tests" {
@@ -255,4 +255,10 @@ fixtures bats
   [ "${lines[4]}" =  'not ok 4 failing' ]
   [ "${lines[5]}" =  "# (in test file $RELATIVE_FIXTURE_ROOT/single_line.bats, line 9)" ]
   [ "${lines[6]}" = $'#   `@test "failing" { false; }\' failed' ]
+}
+
+@test "testing IFS not modified by run" {
+  run bats "$FIXTURE_ROOT/loop_keep_IFS.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 loop_func" ]
 }

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -30,13 +30,13 @@ fixtures bats
 @test "empty test file runs zero tests" {
   run bats "$FIXTURE_ROOT/empty.bats"
   [ $status -eq 0 ]
-  [ $output = "1..0" ]
+  [ "$output" = "1..0" ]
 }
 
 @test "one passing test" {
   run bats "$FIXTURE_ROOT/passing.bats"
   [ $status -eq 0 ]
-  [ ${lines[0]} = "1..1" ]
+  [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
 }
 

--- a/test/fixtures/bats/loop_keep_IFS.bats
+++ b/test/fixtures/bats/loop_keep_IFS.bats
@@ -1,0 +1,16 @@
+# see issue #89
+loop_func() {
+  local search="none one two tree"
+  local d
+
+  for d in $search ; do
+    echo $d
+  done
+}
+
+@test "loop_func" {
+  run loop_func
+  [[ "${lines[3]}" == 'tree' ]]
+  run loop_func
+  [[ "${lines[2]}" == 'two' ]]
+}

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -13,7 +13,7 @@ fixtures suite
   run bats "$FIXTURE_ROOT/single"
   [ $status -eq 0 ]
   [ ${lines[0]} = "1..1" ]
-  [ ${lines[1]} = "ok 1 a passing test" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
 }
 
 @test "counting tests in a suite" {

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -6,30 +6,30 @@ fixtures suite
 @test "running a suite with no test files" {
   run bats "$FIXTURE_ROOT/empty"
   [ $status -eq 0 ]
-  [ $output = "1..0" ]
+  [ "$output" = "1..0" ]
 }
 
 @test "running a suite with one test file" {
   run bats "$FIXTURE_ROOT/single"
   [ $status -eq 0 ]
-  [ ${lines[0]} = "1..1" ]
+  [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
 }
 
 @test "counting tests in a suite" {
   run bats -c "$FIXTURE_ROOT/single"
   [ $status -eq 0 ]
-  [ $output -eq 1 ]
+  [ "$output" -eq 1 ]
 
   run bats -c "$FIXTURE_ROOT/multiple"
   [ $status -eq 0 ]
-  [ $output -eq 3 ]
+  [ "$output" -eq 3 ]
 }
 
 @test "aggregated output of multiple tests in a suite" {
   run bats "$FIXTURE_ROOT/multiple"
   [ $status -eq 0 ]
-  [ ${lines[0]} = "1..3" ]
+  [ "${lines[0]}" = "1..3" ]
   echo "$output" | grep "^ok . truth"
   echo "$output" | grep "^ok . more truth"
   echo "$output" | grep "^ok . quasi-truth"
@@ -38,14 +38,14 @@ fixtures suite
 @test "a failing test in a suite results in an error exit code" {
   FLUNK=1 run bats "$FIXTURE_ROOT/multiple"
   [ $status -eq 1 ]
-  [ ${lines[0]} = "1..3" ]
+  [ "${lines[0]}" = "1..3" ]
   echo "$output" | grep "^not ok . quasi-truth"
 }
 
 @test "running an ad-hoc suite by specifying multiple test files" {
   run bats "$FIXTURE_ROOT/multiple/a.bats" "$FIXTURE_ROOT/multiple/b.bats"
   [ $status -eq 0 ]
-  [ ${lines[0]} = "1..3" ]
+  [ "${lines[0]}" = "1..3" ]
   echo "$output" | grep "^ok . truth"
   echo "$output" | grep "^ok . more truth"
   echo "$output" | grep "^ok . quasi-truth"


### PR DESCRIPTION
IFS was modified by run() becoming '\n' and so relying to its bash default
was failing tests.

Also some wrong tests corrected because was relying on this behavior to pass.

Fix #89