### PR TITLE
Preserve empty output lines in $lines

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -58,7 +58,10 @@ run() {
   output="$("$@" 2>&1)"
   status="$?"
   oldIFS=$IFS
-  IFS=$'\n' lines=($output)
+  lines=()
+  while IFS= read -r LINE; do
+    lines+=( "$LINE" )
+  done < <(echo "$output")
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -57,7 +57,6 @@ run() {
   set +T
   output="$("$@" 2>&1)"
   status="$?"
-  oldIFS=$IFS
   lines=()
   while IFS= read -r LINE; do
     lines+=( "$LINE" )
@@ -65,7 +64,6 @@ run() {
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T
-  IFS=$oldIFS
 }
 
 setup() {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -262,3 +262,12 @@ fixtures bats
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 loop_func" ]
 }
+
+@test "empty lines in output are preserved" {
+  run echo -ne "line0\n\nline2"
+
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" = "line0" ]
+  [ "${lines[1]}" = "" ]
+  [ "${lines[2]}" = "line2" ]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -43,25 +43,25 @@ fixtures bats
 @test "summary passing tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing.bats
   [ $status -eq 0 ]
-  [ "${lines[1]}" = "1 test, 0 failures" ]
+  [ "${lines[2]}" = "1 test, 0 failures" ]
 }
 
 @test "summary passing and skipping tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_and_skipping.bats
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "2 tests, 0 failures, 1 skipped" ]
+  [ "${lines[3]}" = "2 tests, 0 failures, 1 skipped" ]
 }
 
 @test "summary passing and failing tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/failing_and_passing.bats
   [ $status -eq 0 ]
-  [ "${lines[4]}" = "2 tests, 1 failure" ]
+  [ "${lines[5]}" = "2 tests, 1 failure" ]
 }
 
 @test "summary passing, failing and skipping tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_failing_and_skipping.bats
   [ $status -eq 0 ]
-  [ "${lines[5]}" = "3 tests, 1 failure, 1 skipped" ]
+  [ "${lines[6]}" = "3 tests, 1 failure, 1 skipped" ]
 }
 
 @test "one failing test" {


### PR DESCRIPTION
Empty lines in `$output` are lost when the `$lines` array is set. That throws off the expected array index of any lines that follow. This patch preserves those empty lines.

Note that the loop was used to support Bash < 4. Otherwise I would have used the new `readarray` builtin.
