### PR TITLE
Solaris cp dereferences links by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,8 +29,8 @@ fi
 
 BATS_ROOT="$(abs_dirname "$0")"
 mkdir -p "$PREFIX"/{bin,libexec,share/man/man{1,7}}
-cp -R "$BATS_ROOT"/bin/* "$PREFIX"/bin
-cp -R "$BATS_ROOT"/libexec/* "$PREFIX"/libexec
+cp -PR "$BATS_ROOT"/bin/* "$PREFIX"/bin
+cp -PR "$BATS_ROOT"/libexec/* "$PREFIX"/libexec
 cp "$BATS_ROOT"/man/bats.1 "$PREFIX"/share/man/man1
 cp "$BATS_ROOT"/man/bats.7 "$PREFIX"/share/man/man7
 


### PR DESCRIPTION
Solaris cp dereferences links by default, whereas Linux does not. This change brings both OS to same behaviour
Tested on Solaris 10 & RHEL 6