### PR TITLE
bats_print_failed_command: Include $output if available.

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -163,6 +163,10 @@ bats_print_failed_command() {
   else
     echo "failed with status $status"
   fi
+
+  if [ -n "$output" ]; then
+      echo "#   $output"
+  fi
 }
 
 bats_frame_lineno() {


### PR DESCRIPTION
Checking `$status` right after a `run` seems to be a quite regular use case:

```
@test "run will fail" {
    run blahblah
    [[ "$status" -eq 0 ]]
}
```

With this change, the `$output` of run is included in case of failure, which makes debugging much easier:

```
 ✗ run will fail
   (in test file broken.bats, line 7)
     `[[ "$status" -eq 0 ]]' failed
     bats/libexec/bats-exec-test: line 58: blahblah: command not found
```
