### PR TITLE
bash has $COLUMNS builtin

### DIFF
--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -21,7 +21,7 @@ else
 fi
 
 update_screen_width() {
-  screen_width="$(tput cols)"
+  screen_width=${COLUMNS:-$(tput cols)}
   count_column_left=$(( $screen_width - $count_column_width ))
 }
 


### PR DESCRIPTION
http://www.delorie.com/gnu/docs/bash/bashref_62.html

use $COLUMNS variable, if present, avoiding executing tput from ncurses package.

the code does not seem to handle nicely if tput is missing somewhy, imho should 2>/dev/null the invocation and skip if that gave no output