### PR TITLE
Added echoing the output when using run

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -57,6 +57,7 @@ run() {
   set +T
   output="$("$@" 2>&1)"
   status="$?"
+  echo "$output"
   oldIFS=$IFS
   IFS=$'\n' lines=($output)
   [ -z "$e" ] || set -e


### PR DESCRIPTION
That way you get the output if the test fails, until now the output was being
swallowed by the run function