### PR TITLE
Add the ability to include other test files

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -26,7 +26,7 @@ else
   shift
 fi
 
-BATS_TEST_DIRNAME="$(dirname "$BATS_TEST_FILENAME")"
+export BATS_TEST_DIRNAME="$(dirname "$BATS_TEST_FILENAME")"
 BATS_TEST_NAMES=()
 
 load() {

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -30,12 +30,29 @@ encode_name() {
 }
 
 tests=()
-index=0
-pattern='^ *@test  *([^ ].*)  *\{ *(.*)$'
+index=${1:-0}
+test_pattern='^ *@test  *([^ ].*)  *\{ *(.*)$'
+include_pattern='^ *include  *(.+)$'
 
 while IFS= read -r line; do
   let index+=1
-  if [[ "$line" =~ $pattern ]]; then
+  if [[ "$line" =~ $include_pattern ]]; then
+    name="${BASH_REMATCH[1]}"
+
+    filename="$BATS_TEST_DIRNAME/${name}.bats"
+    if [ "${name:0:1}" = "/" ]; then
+      filename="${name}"
+    fi
+
+    [ -f "$filename" ] || {
+      echo "bats: $filename does not exist" >&2
+      exit 1
+    }
+
+    output="$($0 $index < "${filename}")"
+    let index+=$(echo "$output" | grep -c bats_test_begin)
+    echo "$output"
+  elif [[ "$line" =~ $test_pattern ]]; then
     quoted_name="${BASH_REMATCH[1]}"
     body="${BASH_REMATCH[2]}"
     name="$(eval echo "$quoted_name")"

--- a/test/fixtures/suite/include/a.bats
+++ b/test/fixtures/suite/include/a.bats
@@ -1,0 +1,7 @@
+include include/b
+
+export INCLUDER=a
+
+@test "a truth" {
+  true
+}

--- a/test/fixtures/suite/include/c.bats
+++ b/test/fixtures/suite/include/c.bats
@@ -1,0 +1,7 @@
+include include/b
+
+export INCLUDER=c
+
+@test "c truth" {
+  true
+}

--- a/test/fixtures/suite/include/include/b.bats
+++ b/test/fixtures/suite/include/include/b.bats
@@ -1,0 +1,3 @@
+@test "shared truth via $INCLUDER" {
+  true
+}

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -62,3 +62,13 @@ fixtures suite
   [ "${lines[5]}" = "begin 3 quasi-truth" ]
   [ "${lines[6]}" = "not ok 3 quasi-truth" ]
 }
+
+@test "including shared tests" {
+  run bats "$FIXTURE_ROOT/include"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..4" ]
+  echo "$output" | grep "^ok . a truth"
+  echo "$output" | grep "^ok . c truth"
+  echo "$output" | grep "^ok . shared truth via a"
+  echo "$output" | grep "^ok . shared truth via c"
+}


### PR DESCRIPTION
Adds an `include` directive that operates similar to `load` but allows
you to include other bats test files rather than just bash scripts which allows for a simple way to DRY up similar tests.

See the added tests for a simple example of how this functionality might be used.

I can add documentation for this, but wanted to get feedback on the implementation first.

Thank you!
