### PR TITLE
Unset CDPATH

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -56,6 +56,7 @@ BATS_LIBEXEC="$(abs_dirname "$0")"
 export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"
+export CDPATH=""
 
 options=()
 arguments=()


### PR DESCRIPTION
Fixes: GH-104

### Without

```
[marca@marca-mac2 ansible-heroku-output]$ echo $CDPATH
.:/Users/marca/dev/surveymonkey:/Users/marca/dev/git-repos:/Users/marca/dev/hg-repos

[marca@marca-mac2 ansible-heroku-output]$ ~/dev/git-repos/bats/bin/bats test/bats/echo_ascii.bats
bats: /Users/marca/dev/git-repos/ansible-heroku-output/test/bats
/Users/marca/dev/git-repos/ansible-heroku-output/test/bats/echo_ascii.bats does not exist
```

### With

```
[marca@marca-mac2 ansible-heroku-output]$ ~/dev/git-repos/bats/bin/bats test/bats/echo_ascii.bats
 ✓ Test playbook with ASCII

1 test, 0 failures
```