### PR TITLE
Unset CDPATH to prevent weird problems

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
+if [ ! -z "$CDPATH" -a -z "$BATS_KEEP_CDPATH" ]; then
+  echo "Unsetting CDPATH to prevent problems like https://github.com/sstephenson/bats/issues/104 ..."
+  echo "To suppress this behavior, set BATS_KEEP_CDPATH"
+  echo "You may want to consider not exporting CDPATH"
+  unset CDPATH
+fi
 
 version() {
   echo "Bats 0.4.0"


### PR DESCRIPTION
but allow suppressing this behavior in case someone is testing something that relies on `CDPATH`.

Fixes: https://github.com/sstephenson/bats/issues/104

```
[marca@marca-mac2 ansible-heroku-output]$ ~/dev/git-repos/bats/bin/bats test/bats/echo_ascii.bats
Unsetting CDPATH to prevent problems like https://github.com/sstephenson/bats/issues/104 ...
To suppress this behavior, set BATS_KEEP_CDPATH
You may want to consider not exporting CDPATH
 ✓ Test playbook with ASCII

1 test, 0 failures

[marca@marca-mac2 ansible-heroku-output]$ BATS_KEEP_CDPATH=1 ~/dev/git-repos/bats/bin/bats test/bats/echo_ascii.bats
bats: /Users/marca/dev/git-repos/ansible-heroku-output/test/bats
/Users/marca/dev/git-repos/ansible-heroku-output/test/bats/echo_ascii.bats does not exist
```
