### PR TITLE
.travis.yml: comply with the new Travis CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: c
 script: bin/bats --tap test
 notifications:


### PR DESCRIPTION
[since december 2014](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/), Travis CI is providing a faster infrastructure to run our builds. I noticed this project still uses the old infra

> ![2015-09-08_23h56_01](https://cloud.githubusercontent.com/assets/42300/9748829/fbcd79d4-5687-11e5-904a-e60436fb4c6b.png)

This PR meets the new Travis CI requirements so that builds will be made on the new infrastructure.

reference: http://docs.travis-ci.com/user/migrating-from-legacy/
