### PR TITLE
Redirecting cd stdout to /dev/null to avoid CDPATH noise

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,13 +10,13 @@ abs_dirname() {
   local path="$1"
 
   while [ -n "$path" ]; do
-    cd "${path%/*}"
+    cd "${path%/*}" >/dev/null
     local name="${path##*/}"
     path="$(resolve_link "$name" || true)"
   done
 
   pwd
-  cd "$cwd"
+  cd "$cwd" >/dev/null
 }
 
 PREFIX="$1"

--- a/libexec/bats
+++ b/libexec/bats
@@ -35,19 +35,19 @@ abs_dirname() {
   local path="$1"
 
   while [ -n "$path" ]; do
-    cd "${path%/*}"
+    cd "${path%/*}" >/dev/null
     local name="${path##*/}"
     path="$(resolve_link "$name" || true)"
   done
 
   pwd
-  cd "$cwd"
+  cd "$cwd" >/dev/null
 }
 
 expand_path() {
-  { cd "$(dirname "$1")" 2>/dev/null
+  { cd "$(dirname "$1")" >/dev/null 2>&1
     local dirname="$PWD"
-    cd "$OLDPWD"
+    cd "$OLDPWD" >/dev/null
     echo "$dirname/$(basename "$1")"
   } || echo "$1"
 }

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -150,7 +150,7 @@ fixtures bats
 }
 
 @test "failing test file outside of BATS_CWD" {
-  cd "$TMP"
+  cd "$TMP" >/dev/null
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
   [ "${lines[2]}" = "# (in test file $FIXTURE_ROOT/failing.bats, line 4)" ]


### PR DESCRIPTION
Wether or not CDPATH is set, the 'cd' builtin stdout should be redirected to /dev/null to avoid any issue.
See #104 #119 
