### PR TITLE
Avoiding double slash when setting the target installation path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,8 @@ abs_dirname() {
   cd "$cwd"
 }
 
-PREFIX="$1"
-if [ -z "$1" ]; then
+PREFIX="${1%/}"
+if [ -z "$PREFIX" ]; then
   { echo "usage: $0 <prefix>"
     echo "  e.g. $0 /usr/local"
   } >&2


### PR DESCRIPTION
When installing `bats` in my local env, I used `/usr/local/` as argument for `install.sh`.
The generated path for `bats` installation was `/usr/local//bin/bats`.

I've just added a very simple login in `install.sh` script to avoid this double slash, supporting both with and without trailing slash in the specified path.