### PR TITLE
remove required .bash extension for load()

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ test cases in the file. The first run counts the number of test cases,
 then iterates over the test cases and executes each one in its own
 process.
 
-For more details about how Bats evaluates test files, see 
+For more details about how Bats evaluates test files, see
 [Bats Evaluation Process](https://github.com/sstephenson/bats/wiki/Bats-Evaluation-Process)
 on the wiki.
 
@@ -125,7 +125,7 @@ relative to the location of the current test file. For example, if you
 have a Bats test in `test/foo.bats`, the command
 
 ```bash
-load test_helper
+load test_helper.bash
 ```
 
 will source the script `test/test_helper.bash` in your test file. This

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -36,7 +36,7 @@ load() {
   if [ "${name:0:1}" = "/" ]; then
     filename="${name}"
   else
-    filename="$BATS_TEST_DIRNAME/${name}.bash"
+    filename="$BATS_TEST_DIRNAME/${name}"
   fi
 
   [ -f "$filename" ] || {

--- a/man/bats.7
+++ b/man/bats.7
@@ -79,7 +79,7 @@ You may want to share common code across multiple test files\. Bats includes a c
 .
 .nf
 
-load test_helper
+load test_helper\.bash
 .
 .fi
 .

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -71,7 +71,7 @@ includes a convenient `load` command for sourcing a Bash source file
 relative to the location of the current test file. For example, if you
 have a Bats test in `test/foo.bats`, the command
 
-    load test_helper
+    load test_helper.bash
 
 will source the script `test/test_helper.bash` in your test file. This
 can be useful for sharing functions to set up your environment or load

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load test_helper
+load test_helper.bash
 fixtures bats
 
 @test "no arguments prints usage instructions" {

--- a/test/fixtures/bats/failing_helper.bats
+++ b/test/fixtures/bats/failing_helper.bats
@@ -1,4 +1,4 @@
-load "test_helper"
+load "test_helper.bash"
 
 @test "failing helper function" {
   true

--- a/test/fixtures/bats/load.bats
+++ b/test/fixtures/bats/load.bats
@@ -1,4 +1,4 @@
-[ -n "$HELPER_NAME" ] || HELPER_NAME="test_helper"
+[ -n "$HELPER_NAME" ] || HELPER_NAME="test_helper.bash"
 load "$HELPER_NAME"
 
 @test "calling a loaded helper" {

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load test_helper
+load test_helper.bash
 fixtures suite
 
 @test "running a suite with no test files" {


### PR DESCRIPTION
Allow load() to be used for bringing in an external bash script and testing individual functions without forcing a rename. 

This is a breaking change for previous uses of load.