### PR TITLE
This commit corrects the problem of incorrect TAP format for skipped tests.

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -244,11 +244,12 @@ bats_exit_trap() {
   local skipped
   trap - err exit
 
+
   skipped=""
   if [ -n "$BATS_TEST_SKIPPED" ]; then
     skipped=" # skip"
     if [ "1" != "$BATS_TEST_SKIPPED" ]; then
-      skipped+=" ($BATS_TEST_SKIPPED)"
+      skipped+=" $BATS_TEST_SKIPPED"
     fi
   fi
 
@@ -259,7 +260,7 @@ bats_exit_trap() {
     sed -e "s/^/# /" < "$BATS_OUT" >&3
     status=1
   else
-    echo "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}" >&3
+    echo "ok ${BATS_TEST_NUMBER} ${BATS_TEST_DESCRIPTION}${skipped}" >&3
     status=0
   fi
 

--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -144,7 +144,7 @@ while IFS= read -r line; do
     flush
     ;;
   "ok "* )
-    skip_expr="ok $index # skip (\(([^)]*)\))?"
+    skip_expr="ok $index (.*) # skip ?(([^)]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       let skipped+=1
       buffer skip "${BASH_REMATCH[2]}"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -49,7 +49,16 @@ fixtures bats
 @test "summary passing and skipping tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_and_skipping.bats
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "2 tests, 0 failures, 1 skipped" ]
+  [ "${lines[3]}" = "3 tests, 0 failures, 2 skipped" ]
+}
+
+@test "tap passing and skipping tests" {
+  run filter_control_sequences bats --tap $FIXTURE_ROOT/passing_and_skipping.bats
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+  [ "${lines[2]}" = "ok 2 a skipping test # skip" ]
+  [ "${lines[3]}" = "ok 3 skip test with a reason # skip for a really good reason" ]
 }
 
 @test "summary passing and failing tests" {
@@ -62,6 +71,15 @@ fixtures bats
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_failing_and_skipping.bats
   [ $status -eq 0 ]
   [ "${lines[5]}" = "3 tests, 1 failure, 1 skipped" ]
+}
+
+@test "tap passing, failing and skipping tests" {
+  run filter_control_sequences bats --tap $FIXTURE_ROOT/passing_failing_and_skipping.bats
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+  [ "${lines[2]}" = "ok 2 a skipping test # skip" ]
+  [ "${lines[3]}" = "not ok 3 a failing test" ]
 }
 
 @test "one failing test" {
@@ -214,8 +232,8 @@ fixtures bats
 @test "skipped tests" {
   run bats "$FIXTURE_ROOT/skipped.bats"
   [ $status -eq 0 ]
-  [ "${lines[1]}" = "ok 1 # skip a skipped test" ]
-  [ "${lines[2]}" = "ok 2 # skip (a reason) a skipped test with a reason" ]
+  [ "${lines[1]}" = "ok 1 a skipped test # skip" ]
+  [ "${lines[2]}" = "ok 2 a skipped test with a reason # skip a reason" ]
 }
 
 @test "extended syntax" {

--- a/test/fixtures/bats/passing_and_skipping.bats
+++ b/test/fixtures/bats/passing_and_skipping.bats
@@ -5,3 +5,7 @@
 @test "a skipping test" {
   skip
 }
+
+@test "skip test with a reason" {
+  skip "for a really good reason"
+}


### PR DESCRIPTION
As reported in issue #141 , TAP format is incorrect.  This PR corrects the problem, and adds a test case that uses the "skip reason" feature of BATS to ensure the correct output is produced.
