### PR TITLE
Make `load` handle free filename too

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -35,6 +35,8 @@ load() {
 
   if [ "${name:0:1}" = "/" ]; then
     filename="${name}"
+  elif [ -f "$BATS_TEST_DIRNAME/${name}" ]; then
+    filename="$BATS_TEST_DIRNAME/${name}"
   else
     filename="$BATS_TEST_DIRNAME/${name}.bash"
   fi

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -161,6 +161,13 @@ fixtures bats
   [ $status -eq 0 ]
 }
 
+@test "load sources scripts by free filename" {
+  HELPER_NAME="test_helper_freename.sh" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
+  HELPER_NAME="test_helper.bash" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
+}
+
 @test "load aborts if the specified script does not exist" {
   HELPER_NAME="nonexistent" run bats "$FIXTURE_ROOT/load.bats"
   [ $status -eq 1 ]

--- a/test/fixtures/bats/test_helper_freename.sh
+++ b/test/fixtures/bats/test_helper_freename.sh
@@ -1,0 +1,3 @@
+help_me() {
+  true
+}


### PR DESCRIPTION
I want to load `my_helper.sh`
But bats add `.bash` to forcibly my filename, and then the test failed with error.
## Problem

``` console:
$ cd test/fixtures/bats/
$ echo 'help_me() { true; }' > my_helper.sh
$ HELPER_NAME=my_helper.sh bats load.bats
bats: /path/to/bats/my_helper.sh.bash does not exist

$ # It also fails
$ HELPER_NAME=test_helper.bash bats load.bats
bats: /path/to/bats/test_helper.bash.bash does not exist
```
## Solved

I solved the problem.
If the file exists, bats use it.

``` console:
$ cd test/fixtures/bats/
$ echo 'help_me() { true; }' > my_helper.sh
$ HELPER_NAME=my_helper.sh bats load.bats
 ✓ calling a loaded helper

1 test, 0 failures

$ HELPER_NAME=test_helper.bash bats load.bats
 ✓ calling a loaded helper

1 test, 0 failures
```
