### PR TITLE
adds ability to output TAP to file and release STDOUT from tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,39 @@ You can force TAP output from a terminal by invoking Bats with the
     ok 1 addition using bc
     ok 2 addition using dc
 
+As stated previously you can redirect the output to a file and it
+will be in TAP format, but you can specify to write the output to 
+a file using the '-o' option which will be in pretty format.
+
+    $ bats -o addition.tap addition.bats
+    $ cat addition.tap
+
+     ✓ addition using bc
+     ✓ addition using dc
+
+    2 tests, 0 failures
+
+You may also tell it to do the same in TAP format using --tap parameter.  
+Finally, if output has been redirected using -o then you may also tell
+bats to release output from tests and commands run in tests on STDOUT.
+For instance, if you have a test file like:
+
+```bats
+@test "echo something" {
+  echo something
+  [ 0 -eq 0 ]
+}
+```
+
+Then you would get this:
+
+    $ bats --tap -r -o echo.tap echo.bats
+    something
+    $ cat echo.tap 
+    1..1
+    ok 1 echo something
+
+
 ### Test suites
 
 You can invoke the `bats` interpreter with multiple test file

--- a/libexec/bats
+++ b/libexec/bats
@@ -55,7 +55,7 @@ expand_path() {
   } || echo "$1"
 }
 
-BATS_LIBEXEC="$(abs_dirname "$0")"
+export BATS_LIBEXEC="$(abs_dirname "$0")"
 export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"

--- a/libexec/bats
+++ b/libexec/bats
@@ -170,14 +170,18 @@ fi
 set -o pipefail execfail
 
 if [[ -n $BATS_RELEASE_OUTPUT && -z $BATS_TAPOUT_FILE  ]]; then
-# covers: -r
+  # covers: -r
   echo "ERROR: Cannot release output of tests to STDOUT and produce TAP output to STDOUT"  2>&1
   exit 1
 else
   if [[ -n $BATS_TAPOUT_FILE ]]; then
     # covers: -r -o t.tap || -o t.tap
+    set +e
     "$command" $pass_the_opts $extended_syntax_flag "${filenames[@]}"
+    status=$?
+    set -e
     cat $TMPFILE1 | "$formatter" > $BATS_TAPOUT_FILE
+    exit $status
   else
     # (near) original command: no tapout file, no release to STDOUT - will spew test results on STDOUT
     exec "$command" $pass_the_opts $extended_syntax_flag "${filenames[@]}" | "$formatter"

--- a/libexec/bats
+++ b/libexec/bats
@@ -8,7 +8,7 @@ version() {
 
 usage() {
   version
-  echo "Usage: bats [-c] [-p | -t] <test> [<test> ...]"
+  echo "Usage: bats [-c] [-p | -t] [-r] [-o <filename>] <test> [<test> ...]"
 }
 
 help() {

--- a/libexec/bats
+++ b/libexec/bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+
 version() {
   echo "Bats 0.4.0"
 }
@@ -20,6 +21,8 @@ help() {
   echo "  -h, --help     Display this help message"
   echo "  -p, --pretty   Show results in pretty format (default for terminals)"
   echo "  -t, --tap      Show results in TAP format"
+  echo "  -o <filename>  Write test results to <filename>"
+  echo "  -r             Release output from tests to STDOUT"
   echo "  -v, --version  Display the version number"
   echo
   echo "  For more information, see https://github.com/sstephenson/bats"
@@ -57,59 +60,85 @@ export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"
 
-options=()
-arguments=()
-for arg in "$@"; do
-  if [ "${arg:0:1}" = "-" ]; then
-    if [ "${arg:1:1}" = "-" ]; then
-      options[${#options[*]}]="${arg:2}"
-    else
-      index=1
-      while option="${arg:$index:1}"; do
-        [ -n "$option" ] || break
-        options[${#options[*]}]="$option"
-        let index+=1
-      done
-    fi
-  else
-    arguments[${#arguments[*]}]="$arg"
-  fi
-done
+source $BATS_LIBEXEC/common_functions.shrc
 
-unset count_flag pretty
+unset pass_the_opts pretty
 [ -t 0 ] && [ -t 1 ] && pretty="1"
 [ -n "$CI" ] && pretty=""
 
-for option in "${options[@]}"; do
-  case "$option" in
-  "h" | "help" )
-    help
-    exit 0
-    ;;
-  "v" | "version" )
-    version
-    exit 0
-    ;;
-  "c" | "count" )
-    count_flag="-c"
-    ;;
-  "t" | "tap" )
-    pretty=""
-    ;;
-  "p" | "pretty" )
-    pretty="1"
-    ;;
-  * )
-    usage >&2
-    exit 1
-    ;;
+while getopts ":hvctpro:-:" opt; do
+  if [[ $opt == '-' ]]; then
+	case $OPTARG in
+	  'pretty')
+	     opt=p;;
+	  'tap') 
+	     opt=t;;
+	  'help')
+	     opt=h;;
+	  'version')
+	     opt=v;;
+	  *)
+	    if [ "$OPTERR" = 1 ] && [ "${optspec:0:1}" != ":" ]; then
+	 	echo "Unknown option --${OPTARG}" >&2
+	    fi
+	    exit 1
+	  ;;
+	esac
+  fi
+  case $opt in
+    h)
+       help
+       exit 0
+       ;;
+    v)
+      version
+      exit 0
+      ;;
+    c)
+      pass_the_opts="$pass_the_opts -c"
+      ;;
+    r)
+      pass_the_opts="$pass_the_opts -r"
+      BATS_RELEASE_OUTPUT=1
+      ;;
+    t)
+      pretty=""
+      ;;
+    p)
+      pretty="1"
+      ;;
+    o)
+      TMPFILE1=$(createTempFile)
+      pass_the_opts="$pass_the_opts -o $TMPFILE1"
+      BATS_TAPOUT_FILE=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
   esac
 done
+shift $((OPTIND-1))
+
+arguments=("${@}") 
 
 if [ "${#arguments[@]}" -eq 0 ]; then
   usage >&2
   exit 1
 fi
+
+bats_exit_trap() {
+	# remove rubbish
+	if [[ -e $TMPFILE1 ]]; then
+		rm -f $TMPFILE1
+	fi
+}
+trap "bats_exit_trap" exit
+
 
 filenames=()
 for filename in "${arguments[@]}"; do
@@ -139,4 +168,18 @@ else
 fi
 
 set -o pipefail execfail
-exec "$command" $count_flag $extended_syntax_flag "${filenames[@]}" | "$formatter"
+
+if [[ -n $BATS_RELEASE_OUTPUT && -z $BATS_TAPOUT_FILE  ]]; then
+# covers: -r
+  echo "ERROR: Cannot release output of tests to STDOUT and produce TAP output to STDOUT"  2>&1
+  exit 1
+else
+  if [[ -n $BATS_TAPOUT_FILE ]]; then
+    # covers: -r -o t.tap || -o t.tap
+    "$command" $pass_the_opts $extended_syntax_flag "${filenames[@]}"
+    cat $TMPFILE1 | "$formatter" > $BATS_TAPOUT_FILE
+  else
+    # (near) original command: no tapout file, no release to STDOUT - will spew test results on STDOUT
+    exec "$command" $pass_the_opts $extended_syntax_flag "${filenames[@]}" | "$formatter"
+  fi
+fi

--- a/libexec/bats-exec-suite
+++ b/libexec/bats-exec-suite
@@ -1,17 +1,38 @@
 #!/usr/bin/env bash
 set -e
 
-count_only_flag=""
-if [ "$1" = "-c" ]; then
-  count_only_flag=1
-  shift
-fi
+source $BATS_LIBEXEC/common_functions.shrc
 
+unset pass_the_opts
+count_only_flag=""
 extended_syntax_flag=""
-if [ "$1" = "-x" ]; then
-  extended_syntax_flag="-x"
-  shift
-fi
+while getopts ":o:cxr" opt; do
+  case $opt in
+    c)
+       count_only_flag=1
+      ;;
+    x)
+      extended_syntax_flag="-x"
+      pass_the_opts="$pass_the_opts -x"
+      ;;
+    o)
+      export BATS_OUTPUT_FILE=$OPTARG
+      pass_the_opts="$pass_the_opts -o $BATS_OUTPUT_FILE"
+      ;;
+    r)
+      pass_the_opts="$pass_the_opts -r"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
 
 trap "kill 0; exit 1" int
 
@@ -20,36 +41,61 @@ for filename in "$@"; do
   let count+="$(bats-exec-test -c "$filename")"
 done
 
+# Set up the location of TAP output and location of run outputs
+if [[ -n $BATS_OUTPUT_FILE ]]; then
+	# Store output in temp file and overwrite BATS_OUTPUT_FILE with it later
+	TMP_TAP_FILE=$(createTempFile)
+        exec 4>$TMP_TAP_FILE
+else
+        exec 4<&1 # copy STDOUT file descriptor and use that instead of assuming STDOUT as the file descriptor of outputs
+fi
+
 if [ -n "$count_only_flag" ]; then
-  echo "$count"
+  >&4 echo "$count"
   exit
 fi
 
-echo "1..$count"
+>&4 echo "1..$count"
 status=0
 offset=0
 for filename in "$@"; do
   index=0
+    if [[ -n $BATS_OUTPUT_FILE ]]; then
+      echo -n "" > $BATS_OUTPUT_FILE  # zero out the file
+set +e
+      bats-exec-test $pass_the_opts "$filename"
+set -e
+      exec 5<$BATS_OUTPUT_FILE
+    else
+      exec 5< <( bats-exec-test $pass_the_opts "$filename" )
+    fi
+
   {
-    IFS= read -r # 1..n
+    IFS= read -r myline # 1..n
     while IFS= read -r line; do
       case "$line" in
       "begin "* )
         let index+=1
-        echo "${line/ $index / $(($offset + $index)) }"
+        >&4 echo "${line/ $index / $(($offset + $index)) }"
         ;;
       "ok "* | "not ok "* )
         [ -n "$extended_syntax_flag" ] || let index+=1
-        echo "${line/ $index / $(($offset + $index)) }"
+        >&4 echo "${line/ $index / $(($offset + $index)) }"
         [ "${line:0:6}" != "not ok" ] || status=1
         ;;
       * )
-        echo "$line"
+        >&4 echo "$line"
         ;;
       esac
     done
-  } < <( bats-exec-test $extended_syntax_flag "$filename" )
+  } <&5
+
   offset=$(($offset + $index))
 done
+
+if [[ -n $BATS_OUTPUT_FILE ]]; then
+	# move temp file over BATS_OUTPUT_FILE
+	mv -f $TMP_TAP_FILE $BATS_OUTPUT_FILE
+fi
 
 exit "$status"

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -3,17 +3,36 @@ set -e
 set -E
 set -T
 
-BATS_COUNT_ONLY=""
-if [ "$1" = "-c" ]; then
-  BATS_COUNT_ONLY=1
-  shift
-fi
+source common_functions.shrc
 
+BATS_COUNT_ONLY=""
 BATS_EXTENDED_SYNTAX=""
-if [ "$1" = "-x" ]; then
-  BATS_EXTENDED_SYNTAX="$1"
-  shift
-fi
+while getopts ":o:cxr" opt; do
+  case $opt in
+    c)
+      BATS_COUNT_ONLY=1
+      ;;
+    x)
+      BATS_EXTENDED_SYNTAX="-x"
+      ;;
+    o)
+      export BATS_OUTPUT_FILE=$OPTARG
+      ;;
+    r)
+      export BATS_RELEASE_TESTOUTPUT=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
 
 BATS_TEST_FILENAME="$1"
 if [ -z "$BATS_TEST_FILENAME" ]; then
@@ -113,7 +132,6 @@ bats_capture_stack_trace() {
       let index+=1
     fi
   done
-
   BATS_SOURCE="$(bats_frame_filename "${BATS_CURRENT_STACK_TRACE[0]}")"
   BATS_LINENO="$(bats_frame_lineno "${BATS_CURRENT_STACK_TRACE[0]}")"
 }
@@ -268,7 +286,7 @@ bats_exit_trap() {
 }
 
 bats_perform_tests() {
-  echo "1..$#"
+  echo "1..$#" >&3
   test_number=1
   status=0
   for test_name in "$@"; do
@@ -283,7 +301,7 @@ bats_perform_test() {
   if [ "$(type -t "$BATS_TEST_NAME" || true)" = "function" ]; then
     BATS_TEST_NUMBER="$2"
     if [ -z "$BATS_TEST_NUMBER" ]; then
-      echo "1..1"
+      echo "1..1" >&3
       BATS_TEST_NUMBER="1"
     fi
 
@@ -292,23 +310,22 @@ bats_perform_test() {
     trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
     trap "bats_error_trap" err
     trap "bats_teardown_trap" exit
-    "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
-    BATS_TEST_COMPLETED=1
 
+    if [[ -n $BATS_RELEASE_TESTOUTPUT ]]; then
+       2>&1 "$BATS_TEST_NAME" > >(tee "$BATS_OUT")
+    else
+      "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
+    fi
+    BATS_TEST_COMPLETED=1
   else
     echo "bats: unknown test name \`$BATS_TEST_NAME'" >&2
     exit 1
   fi
 }
 
-if [ -z "$TMPDIR" ]; then
-  BATS_TMPDIR="/tmp"
-else
-  BATS_TMPDIR="${TMPDIR%/}"
-fi
-
-BATS_TMPNAME="$BATS_TMPDIR/bats.$$"
-BATS_PARENT_TMPNAME="$BATS_TMPDIR/bats.$PPID"
+BATS_TMPDIR=$(getTmpDir)
+BATS_TMPNAME=$(createTempFile $$ 0)            # returns same result on each call
+BATS_PARENT_TMPNAME=$(createTempFile $PPID 0)  # ditto
 BATS_OUT="${BATS_TMPNAME}.out"
 
 bats_preprocess_source() {
@@ -329,7 +346,12 @@ bats_evaluate_preprocessed_source() {
   source "$BATS_TEST_SOURCE"
 }
 
-exec 3<&1
+# Set up the location of TAP output and location of run outputs
+if [[ -n $BATS_OUTPUT_FILE ]]; then
+	exec 3>>$BATS_OUTPUT_FILE
+else
+	exec 3<&1 # copy STDOUT file descriptor and use that instead of assuming STDOUT as the file descriptor of outputs
+fi
 
 if [ "$#" -eq 0 ]; then
   bats_preprocess_source
@@ -338,9 +360,9 @@ if [ "$#" -eq 0 ]; then
   if [ -n "$BATS_COUNT_ONLY" ]; then
     echo "${#BATS_TEST_NAMES[@]}"
   else
-    bats_perform_tests "${BATS_TEST_NAMES[@]}"
+    bats_perform_tests "${BATS_TEST_NAMES[@]}" 
   fi
 else
   bats_evaluate_preprocessed_source
-  bats_perform_test "$@"
+  bats_perform_test "$@" 
 fi

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -244,11 +244,12 @@ bats_exit_trap() {
   local skipped
   trap - err exit
 
+
   skipped=""
   if [ -n "$BATS_TEST_SKIPPED" ]; then
     skipped=" # skip"
     if [ "1" != "$BATS_TEST_SKIPPED" ]; then
-      skipped+=" ($BATS_TEST_SKIPPED)"
+      skipped+=" $BATS_TEST_SKIPPED"
     fi
   fi
 
@@ -259,7 +260,7 @@ bats_exit_trap() {
     sed -e "s/^/# /" < "$BATS_OUT" >&3
     status=1
   else
-    echo "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}" >&3
+    echo "ok ${BATS_TEST_NUMBER} ${BATS_TEST_DESCRIPTION}${skipped}" >&3
     status=0
   fi
 

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -74,14 +74,23 @@ run() {
   set +e
   set +E
   set +T
-  output="$("$@" 2>&1)"
-  status="$?"
+  if [[ -n $BATS_RELEASE_TESTOUTPUT ]]; then
+    local TMPFILE=$(createTempFile)
+    "$@" > >(tee $TMPFILE) 2>&1
+    status="$?"
+    output=$(cat $TMPFILE)
+    rm -f $TMPFILE
+  else
+    output="$("$@" 2>&1)"
+    status="$?"
+  fi
   oldIFS=$IFS
   IFS=$'\n' lines=($output)
+  IFS=$oldIFS
+
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T
-  IFS=$oldIFS
 }
 
 setup() {

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -33,7 +33,6 @@ while getopts ":o:cxr" opt; do
 done
 shift $((OPTIND-1))
 
-
 BATS_TEST_FILENAME="$1"
 if [ -z "$BATS_TEST_FILENAME" ]; then
   echo "usage: bats-exec <filename>" >&2

--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -144,7 +144,7 @@ while IFS= read -r line; do
     flush
     ;;
   "ok "* )
-    skip_expr="ok $index # skip (\(([^)]*)\))?"
+    skip_expr="ok $index (.*) # skip ?(([^)]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       let skipped+=1
       buffer skip "${BASH_REMATCH[2]}"

--- a/libexec/common_functions.shrc
+++ b/libexec/common_functions.shrc
@@ -1,0 +1,28 @@
+
+function getTmpDir() {
+  local MYTMPDIR
+  if [ -z "$TMPDIR" ]; then
+    MYTMPDIR="/tmp"
+  else
+    MYTMPDIR="${TMPDIR%/}"
+   fi
+
+   echo $MYTMPDIR
+}
+
+# Generate temporary filename
+function createTempFile() {
+    local PID="${1:-$$}"
+    local USETEMPLATE="${2:-1}"    
+    local MYTMPDIR=$(getTmpDir)
+
+    if [[ $USETEMPLATE == 1 ]]; then 
+       # generate idempotent file names 
+       TMPFILE=$(mktemp $MYTMPDIR/bats.$PID.XXXXXX)
+       echo $TMPFILE
+    else
+       # if we are not using a template we can call this function many times and get the same response
+       echo $MYTMPDIR/bats.$PID
+    fi
+}
+

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -268,8 +268,9 @@ fixtures bats
   run bats "$FIXTURE_ROOT/echo_output_and_pass.bats"
   [ "$status" -eq 0 ]
 
-  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[0]}" = "1..2" ]
   [ "${lines[1]}" = "ok 1 echo output and pass" ]
+  [ "${lines[2]}" = "ok 2 echo output and pass (using run)" ]
 }
 
 @test "test with output released (in TAP)" {
@@ -285,8 +286,9 @@ fixtures bats
   [ "$status" -eq 0 ]
 
   cat <<EOF | diff - $TMPFILE
-1..1
+1..2
 ok 1 echo output and pass
+ok 2 echo output and pass (using run)
 EOF
 
   rm -f $TMPFILE
@@ -298,8 +300,9 @@ EOF
   [ "$status" -eq 0 ]
 
   cat <<EOF | diff - $TMPFILE
-1..1
+1..2
 ok 1 echo output and pass
+ok 2 echo output and pass (using run)
 EOF
 
   rm -f $TMPFILE
@@ -313,7 +316,7 @@ EOF
   run bats -p "$FIXTURE_ROOT/echo_output_and_pass.bats"
   [ "$status" -eq 0 ]
 
-  [ "${lines[2]}" = "1 test, 0 failures" ]
+  [ "${lines[3]}" = "2 tests, 0 failures" ]
 }
 
 @test "test with output released (in BATS)" {
@@ -329,7 +332,7 @@ EOF
   [ "$status" -eq 0 ]
 
   ACTUAL_LASTLINE=$(tail -1 $TMPFILE)
-  EXPECTED_LASTLINE="1 test, 0 failures"
+  EXPECTED_LASTLINE="2 tests, 0 failures"
   rm -f $TMPFILE
 
   [ "$ACTUAL_LASTLINE" = "$EXPECTED_LASTLINE" ]
@@ -341,7 +344,7 @@ EOF
   [ "$status" -eq 0 ]
 
   ACTUAL_LASTLINE=$(tail -1 $TMPFILE)
-  EXPECTED_LASTLINE="1 test, 0 failures"
+  EXPECTED_LASTLINE="2 tests, 0 failures"
 
   rm -f $TMPFILE
   [ "$ACTUAL_LASTLINE" = "$EXPECTED_LASTLINE" ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load test_helper
+load "$BATS_PREFIX/libexec/common_functions.shrc"
 fixtures bats
 
 @test "no arguments prints usage instructions" {
@@ -262,3 +263,82 @@ fixtures bats
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 loop_func" ]
 }
+
+@test "default test (in TAP)" {
+  run bats "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[1]}" = "ok 1 echo output and pass" ]
+}
+
+@test "test with output released (in TAP)" {
+  run bats -r "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  [ "${lines[0]}" = "ERROR: Cannot release output of tests to STDOUT and produce TAP output to STDOUT" ]
+}
+
+@test "results directed to file (in TAP)" {
+  TMPFILE=$(createTempFile)
+  run bats -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  cat <<EOF | diff - $TMPFILE
+1..1
+ok 1 echo output and pass
+EOF
+
+  rm -f $TMPFILE
+}
+
+@test "test output released and results directed to file (in TAP)" {
+  TMPFILE=$(createTempFile)
+  run bats -r -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  cat <<EOF | diff - $TMPFILE
+1..1
+ok 1 echo output and pass
+EOF
+
+  rm -f $TMPFILE
+
+  [ "${lines[0]}" = "Something from BATS file" ]
+  [ "${lines[1]}" = "something from shell script" ]
+
+}
+
+@test "default test (in BATS)" {
+  run bats -p "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  [ "${lines[2]}" = "1 test, 0 failures" ]
+}
+
+@test "test with output released (in BATS)" {
+  run bats -p -r "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  [ "${lines[0]}" = "ERROR: Cannot release output of tests to STDOUT and produce TAP output to STDOUT" ]
+}
+
+@test "results directed to file (in BATS)" {
+  TMPFILE=$(createTempFile)
+  run bats -p -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  ACTUAL_LASTLINE=$(tail -1 $TMPFILE)
+  EXPECTED_LASTLINE="1 test, 0 failures"
+  rm -f $TMPFILE
+
+  [ "$ACTUAL_LASTLINE" = "$EXPECTED_LASTLINE" ]
+}
+
+@test "test output released and results directed to file (in BATS)" {
+  TMPFILE=$(createTempFile)
+  run bats -p -r -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+
+  ACTUAL_LASTLINE=$(tail -1 $TMPFILE)
+  EXPECTED_LASTLINE="1 test, 0 failures"
+
+  rm -f $TMPFILE
+  [ "$ACTUAL_LASTLINE" = "$EXPECTED_LASTLINE" ]
+
+  [ "${lines[0]}" = "Something from BATS file" ]
+  [ "${lines[1]}" = "something from shell script" ]
+}
+

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -49,7 +49,16 @@ fixtures bats
 @test "summary passing and skipping tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_and_skipping.bats
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "2 tests, 0 failures, 1 skipped" ]
+  [ "${lines[3]}" = "3 tests, 0 failures, 2 skipped" ]
+}
+
+@test "tap passing and skipping tests" {
+  run filter_control_sequences bats --tap $FIXTURE_ROOT/passing_and_skipping.bats
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+  [ "${lines[2]}" = "ok 2 a skipping test # skip" ]
+  [ "${lines[3]}" = "ok 3 skip test with a reason # skip for a really good reason" ]
 }
 
 @test "summary passing and failing tests" {
@@ -62,6 +71,15 @@ fixtures bats
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_failing_and_skipping.bats
   [ $status -eq 0 ]
   [ "${lines[5]}" = "3 tests, 1 failure, 1 skipped" ]
+}
+
+@test "tap passing, failing and skipping tests" {
+  run filter_control_sequences bats --tap $FIXTURE_ROOT/passing_failing_and_skipping.bats
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+  [ "${lines[2]}" = "ok 2 a skipping test # skip" ]
+  [ "${lines[3]}" = "not ok 3 a failing test" ]
 }
 
 @test "one failing test" {
@@ -214,8 +232,8 @@ fixtures bats
 @test "skipped tests" {
   run bats "$FIXTURE_ROOT/skipped.bats"
   [ $status -eq 0 ]
-  [ "${lines[1]}" = "ok 1 # skip a skipped test" ]
-  [ "${lines[2]}" = "ok 2 # skip (a reason) a skipped test with a reason" ]
+  [ "${lines[1]}" = "ok 1 a skipped test # skip" ]
+  [ "${lines[2]}" = "ok 2 a skipped test with a reason # skip a reason" ]
 }
 
 @test "extended syntax" {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -266,6 +266,7 @@ fixtures bats
 
 @test "default test (in TAP)" {
   run bats "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 0 ]
 
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "ok 1 echo output and pass" ]
@@ -273,6 +274,7 @@ fixtures bats
 
 @test "test with output released (in TAP)" {
   run bats -r "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 1 ]
 
   [ "${lines[0]}" = "ERROR: Cannot release output of tests to STDOUT and produce TAP output to STDOUT" ]
 }
@@ -280,6 +282,7 @@ fixtures bats
 @test "results directed to file (in TAP)" {
   TMPFILE=$(createTempFile)
   run bats -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 0 ]
 
   cat <<EOF | diff - $TMPFILE
 1..1
@@ -292,6 +295,7 @@ EOF
 @test "test output released and results directed to file (in TAP)" {
   TMPFILE=$(createTempFile)
   run bats -r -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 0 ]
 
   cat <<EOF | diff - $TMPFILE
 1..1
@@ -307,12 +311,14 @@ EOF
 
 @test "default test (in BATS)" {
   run bats -p "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 0 ]
 
   [ "${lines[2]}" = "1 test, 0 failures" ]
 }
 
 @test "test with output released (in BATS)" {
   run bats -p -r "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 1 ]
 
   [ "${lines[0]}" = "ERROR: Cannot release output of tests to STDOUT and produce TAP output to STDOUT" ]
 }
@@ -320,6 +326,7 @@ EOF
 @test "results directed to file (in BATS)" {
   TMPFILE=$(createTempFile)
   run bats -p -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 0 ]
 
   ACTUAL_LASTLINE=$(tail -1 $TMPFILE)
   EXPECTED_LASTLINE="1 test, 0 failures"
@@ -331,6 +338,7 @@ EOF
 @test "test output released and results directed to file (in BATS)" {
   TMPFILE=$(createTempFile)
   run bats -p -r -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_pass.bats"
+  [ "$status" -eq 0 ]
 
   ACTUAL_LASTLINE=$(tail -1 $TMPFILE)
   EXPECTED_LASTLINE="1 test, 0 failures"
@@ -339,6 +347,21 @@ EOF
   [ "$ACTUAL_LASTLINE" = "$EXPECTED_LASTLINE" ]
 
   [ "${lines[0]}" = "Something from BATS file" ]
+  [ "${lines[1]}" = "something from shell script" ]
+}
+
+@test "test output released and results directed to file (in BATS) when a test is failing" {
+  TMPFILE=$(createTempFile)
+  run bats -p -r -o $TMPFILE  "$FIXTURE_ROOT/echo_output_and_fail.bats"
+  [ "$status" -eq 1 ]
+
+  ACTUAL_LASTLINE=$(tail -1 $TMPFILE)
+  EXPECTED_LASTLINE="1 test, 1 failure"
+
+  rm -f $TMPFILE
+  [ "$ACTUAL_LASTLINE" = "$EXPECTED_LASTLINE" ]
+
+  [ "${lines[0]}" = "Something from echo_output_and_fail.bats" ]
   [ "${lines[1]}" = "something from shell script" ]
 }
 

--- a/test/fixtures/bats/echo_output_and_fail.bats
+++ b/test/fixtures/bats/echo_output_and_fail.bats
@@ -1,0 +1,5 @@
+@test "echo output and fail" {
+	echo "Something from echo_output_and_fail.bats"
+	$BATS_TEST_DIRNAME/echo_something.bash
+	[ 0 -eq 1 ]
+}

--- a/test/fixtures/bats/echo_output_and_pass.bats
+++ b/test/fixtures/bats/echo_output_and_pass.bats
@@ -3,3 +3,9 @@
 	$BATS_TEST_DIRNAME/echo_something.bash
 	[ 0 -eq 0 ]
 }
+
+@test "echo output and pass (using run)" {
+        run $BATS_TEST_DIRNAME/echo_something.bash
+        [ $status -eq 0 ]
+}
+

--- a/test/fixtures/bats/echo_output_and_pass.bats
+++ b/test/fixtures/bats/echo_output_and_pass.bats
@@ -1,0 +1,5 @@
+@test "echo output and pass" {
+	echo "Something from BATS file"
+	$BATS_TEST_DIRNAME/echo_something.bash
+	[ 0 -eq 0 ]
+}

--- a/test/fixtures/bats/echo_something.bash
+++ b/test/fixtures/bats/echo_something.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "something from shell script"

--- a/test/fixtures/bats/passing_and_skipping.bats
+++ b/test/fixtures/bats/passing_and_skipping.bats
@@ -5,3 +5,7 @@
 @test "a skipping test" {
   skip
 }
+
+@test "skip test with a reason" {
+  skip "for a really good reason"
+}

--- a/test/fixtures/suite/release_output/echo_and_fail.bats
+++ b/test/fixtures/suite/release_output/echo_and_fail.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "echo and fail" {
+	echo "this is a failing test"
+	[ 0 -eq 1 ]
+}
+

--- a/test/fixtures/suite/release_output/echo_and_pass.bats
+++ b/test/fixtures/suite/release_output/echo_and_pass.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "echo and pass" {
+	echo "this is a passing test"
+	[ 1 -eq 1 ]
+}
+

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -62,3 +62,33 @@ fixtures suite
   [ "${lines[5]}" = "begin 3 quasi-truth" ]
   [ "${lines[6]}" = "not ok 3 quasi-truth" ]
 }
+
+@test "release output with multiple test files" {
+  TMPFILE=$(createTempFile)
+  run bats -r -o $TMPFILE "$FIXTURE_ROOT/release_output/echo_and_fail.bats" "$FIXTURE_ROOT/release_output/echo_and_pass.bats"
+  [ $status -eq 1 ]
+
+  grep "1..2" $TMPFILE
+  grep "not ok 1 echo and fail" $TMPFILE
+  grep "ok 2 echo and pass" $TMPFILE
+
+  [ "${lines[0]}" = "this is a failing test" ]
+  [ "${lines[1]}" = "this is a passing test" ]
+
+  rm -f $TMPFILE
+}
+
+@test "release output with test suite" {
+  TMPFILE=$(createTempFile)
+  run bats -r -o $TMPFILE "$FIXTURE_ROOT/release_output" 
+  [ $status -eq 1 ]
+
+  grep "1..2" $TMPFILE
+  grep "not ok 1 echo and fail" $TMPFILE
+  grep "ok 2 echo and pass" $TMPFILE
+
+  [ "${lines[0]}" = "this is a failing test" ]
+  [ "${lines[1]}" = "this is a passing test" ]
+
+  rm -f $TMPFILE
+}


### PR DESCRIPTION
This pull request makes bats more amenable to running at command line and for running from inside build systems such as Jenkins.
You can now provide parameters "-t -r -o myresults.tap" and will see any output coming from bats tests or commands that bats tests call that are producing output go directly to STDOUT in real time.   The results of the test will be directed to the file myresults.tap and will be in TAP format per the -t parameter.
The effect is that the Jenkins console will contain the output from the test execution and the tap results can be picked up by the TAP plugin by scanning the workspace for the myresults.tap file.
