### PR TITLE
Use empty CDPATH with `cd` in abs_dirname/expand_path

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -e
+# Set priviledged mode, which also discards CDPATH.
+set -p
 
 version() {
   echo "Bats 0.4.0"


### PR DESCRIPTION
While not recommended [1] `CDPATH` might be exported and would be used
for e.g. `cd test` instead of using `./test`.
E.g. Vim will make use of it (and therefore it needs to be exported, if
you do not want to configure it twice).

Fixes https://github.com/sstephenson/bats/issues/104.

This supersedes https://github.com/sstephenson/bats/pull/119: there is
no need to unset/change CDPATH globally.

1: https://bosker.wordpress.com/2012/02/12/bash-scripters-beware-of-the-cdpath/
