### PR TITLE
Add a JUnit output formatter compatible with Jenkins

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -54,9 +54,9 @@ expand_path() {
   } || echo "$1"
 }
 
-BATS_LIBEXEC="$(abs_dirname "$0")"
-export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
-export BATS_CWD="$(abs_dirname .)"
+BATS_LIBEXEC="${BATS_LIBEXEC-$(abs_dirname "$0")}"
+export BATS_PREFIX="${BATS_PREFIX-$(abs_dirname "$BATS_LIBEXEC")}"
+export BATS_CWD="${BATS_CWD-$(abs_dirname .)}"
 export PATH="$BATS_LIBEXEC:$PATH"
 
 options=()

--- a/libexec/bats
+++ b/libexec/bats
@@ -20,6 +20,8 @@ help() {
   echo "  -h, --help     Display this help message"
   echo "  -p, --pretty   Show results in pretty format (default for terminals)"
   echo "  -t, --tap      Show results in TAP format"
+  echo "  -x, --extended Show results in extended TAP format"
+  echo "  -u, --junit    Show results in JUnit format, hudson compatible"
   echo "  -v, --version  Display the version number"
   echo
   echo "  For more information, see https://github.com/sstephenson/bats"
@@ -93,11 +95,18 @@ for option in "${options[@]}"; do
   "c" | "count" )
     count_flag="-c"
     ;;
+  "x" | "extended" )
+    pretty=""
+    extended_syntax_flag="-x"
+    ;;
   "t" | "tap" )
     pretty=""
     ;;
   "p" | "pretty" )
     pretty="1"
+    ;;
+  "u" | "junit" )
+    junit="1"
     ;;
   * )
     usage >&2
@@ -130,11 +139,13 @@ else
   command="bats-exec-suite"
 fi
 
-if [ -n "$pretty" ]; then
+if [ -n "$junit" ]; then
+  extended_syntax_flag="-x"
+  formatter="bats-format-junit"
+elif [ -n "$pretty" ]; then
   extended_syntax_flag="-x"
   formatter="bats-format-tap-stream"
 else
-  extended_syntax_flag=""
   formatter="cat"
 fi
 

--- a/libexec/bats-exec-suite
+++ b/libexec/bats-exec-suite
@@ -30,6 +30,9 @@ status=0
 offset=0
 for filename in "$@"; do
   index=0
+  if test -n "$extended_syntax_flag"; then
+    echo suite bats.$(basename "$filename"| sed -e 's/\.bats//')
+  fi
   {
     IFS= read -r # 1..n
     while IFS= read -r line; do

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -253,18 +253,19 @@ bats_exit_trap() {
     fi
   fi
 
+  if [ -n "${skipped}" ] || [ -z "$BATS_EXTENDED_SYNTAX" ]; then
+      BATS_TEST_TIME=""
+  else
+      BATS_TEST_TIME=" in "$((SECONDS - BATS_TEST_START_TIME))"sec"
+  fi
+
   if [ -z "$BATS_TEST_COMPLETED" ] || [ -z "$BATS_TEARDOWN_COMPLETED" ]; then
-    echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION${BATS_TEST_TIME}" >&3
     bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
     bats_print_failed_command "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" "$BATS_ERROR_STATUS" >&3
     sed -e "s/^/# /" < "$BATS_OUT" >&3
     status=1
   else
-    if [ -n "${skipped}" ] || [ -z "$BATS_EXTENDED_SYNTAX" ]; then
-      BATS_TEST_TIME=""
-    else
-      BATS_TEST_TIME=" in "$((SECONDS - BATS_TEST_START_TIME))"sec"
-    fi
     echo "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" >&3
     status=0
   fi

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -81,6 +81,7 @@ skip() {
 
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
+  BATS_TEST_START_TIME=${SECONDS}
   if [ -n "$BATS_EXTENDED_SYNTAX" ]; then
     echo "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
   fi
@@ -259,7 +260,12 @@ bats_exit_trap() {
     sed -e "s/^/# /" < "$BATS_OUT" >&3
     status=1
   else
-    echo "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}" >&3
+    if [ -n "${skipped}" ] || [ -z "$BATS_EXTENDED_SYNTAX" ]; then
+      BATS_TEST_TIME=""
+    else
+      BATS_TEST_TIME=" in "$((SECONDS - BATS_TEST_START_TIME))"sec"
+    fi
+    echo "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" >&3
     status=0
   fi
 

--- a/libexec/bats-format-junit
+++ b/libexec/bats-format-junit
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -e
+
+header_pattern='[0-9]+\.\.[0-9]+'
+IFS= read -r header
+
+if [[ "$header" =~ $header_pattern ]]; then
+  count="${header:3}"
+  index=0
+  failures=0
+  skipped=0
+  name=""
+else
+  # If the first line isn't a TAP plan, print it and pass the rest through
+  printf "%s\n" "$header"
+  exec cat
+fi
+
+header() {
+    printf "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuite tests=\"${count}\" failures=\"${failures}\" skip=\"${skipped}\">\n"
+}
+
+footer() {
+    printf "</testsuite>\n"
+}
+
+
+pass() {
+    echo "    <testcase classname=\"$class\" name=\"$name\"/>\n"
+}
+
+fail() {
+    echo "\
+    <testcase classname=\"$class\" name=\"$name\">
+        <failure><![CDATA[$1]]></failure>
+    </testcase>\n"
+}
+
+skip() {
+    echo "\
+    <testcase classname=\"$class\" name=\"$name\">
+        <skipped>$1</skipped>
+    </testcase>\n"
+}
+
+_buffer=""
+
+buffer() {
+  _buffer="${_buffer}$("$@")"
+}
+
+flush() {
+  printf "$_buffer"
+  _buffer=""
+}
+
+_buffer_log=""
+log() {
+    _buffer_log="${_buffer_log}\n$1"
+}
+
+flush_log() {
+  if [[ -n "${_buffer_log}" ]]; then
+		buffer fail "${_buffer_log}"
+		_buffer_log=""
+  fi
+}
+
+finish() {
+    flush_log
+    header
+		flush
+		footer
+}
+
+trap finish EXIT
+
+
+while IFS= read -r line; do
+  case "$line" in
+  "suite "*)
+    flush_log
+    suite_expr="suite (.*)"
+    if [[ "$line" =~ $suite_expr ]]; then
+      class="${BASH_REMATCH[1]}"
+    fi
+    ;;
+  "begin "* )
+    flush_log
+    let index+=1
+    name="${line#* $index }"
+    ;;
+  "ok "* )
+    skip_expr="ok $index # skip (\(([^)]*)\))?"
+    if [[ "$line" =~ $skip_expr ]]; then
+      let skipped+=1
+      buffer skip "${BASH_REMATCH[2]}"
+    else
+      buffer pass
+    fi
+    ;;
+  "not ok "* )
+    let failures+=1
+    ;;
+  "# "* )
+    log "${line:2}"
+    ;;
+  esac
+done
+
+

--- a/libexec/bats-format-junit
+++ b/libexec/bats-format-junit
@@ -30,9 +30,13 @@ pass() {
 }
 
 fail() {
-    echo "\
+    printf "\
     <testcase classname=\"${class}\" name=\"${name}\" time=\"${test_exec_time}\">
-        <failure><![CDATA[$1]]></failure>
+        <failure><![CDATA["
+
+    echo -n "${1}"
+
+    printf "]]></failure>
     </testcase>\n"
 }
 
@@ -48,13 +52,14 @@ buffer() {
 }
 
 flush() {
-  printf "$_buffer"
+  echo "${_buffer}"
   _buffer=""
 }
 
 _buffer_log=""
 log() {
-    _buffer_log="${_buffer_log}\n$1"
+  _buffer_log="${_buffer_log}
+$1"
 }
 
 flush_log() {

--- a/libexec/bats-format-junit
+++ b/libexec/bats-format-junit
@@ -9,6 +9,7 @@ if [[ "$header" =~ $header_pattern ]]; then
   index=0
   failures=0
   skipped=0
+  suitetest_exec_time=0
   name=""
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
@@ -19,7 +20,7 @@ fi
 header() {
     printf "\
 <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<testsuite tests=\"${count}\" failures=\"${failures}\" skip=\"${skipped}\">\n"
+<testsuite tests=\"${count}\" failures=\"${failures}\" skip=\"${skipped}\" time=\"${suitetest_exec_time}\">\n"
 }
 
 footer() {
@@ -99,6 +100,7 @@ while IFS= read -r line; do
       buffer skip "${BASH_REMATCH[2]}"
     elif [[ "$line" =~ $expr_ok ]]; then
       test_exec_time="${BASH_REMATCH[2]}"
+      suitetest_exec_time=$((suitetest_exec_time + test_exec_time))
       buffer pass
     else
       log "Wrong output format: ${line}"

--- a/libexec/bats-format-junit
+++ b/libexec/bats-format-junit
@@ -4,23 +4,21 @@ set -e
 header_pattern='[0-9]+\.\.[0-9]+'
 IFS= read -r header
 
-if [[ "$header" =~ $header_pattern ]]; then
-  count="${header:3}"
-  index=0
+index=0
+
+init_suite() {
+  count=0
   failures=0
   skipped=0
   suitetest_exec_time=0
   name=""
-else
-  # If the first line isn't a TAP plan, print it and pass the rest through
-  printf "%s\n" "$header"
-  exec cat
-fi
+  _buffer=""
+}
 
 header() {
     printf "\
 <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<testsuite tests=\"${count}\" failures=\"${failures}\" skip=\"${skipped}\" time=\"${suitetest_exec_time}\">\n"
+<testsuite name=\"${class}\" tests=\"${count}\" failures=\"${failures}\" skip=\"${skipped}\" time=\"${suitetest_exec_time}\">\n"
 }
 
 footer() {
@@ -46,8 +44,6 @@ skip() {
     </testcase>\n"
 }
 
-_buffer=""
-
 buffer() {
   _buffer="${_buffer}$("$@")"
 }
@@ -69,19 +65,25 @@ flush_log() {
   fi
 }
 
-finish() {
-  flush_log
-  header
-  flush
-  footer
+finish_suite() {
+  [[ ${count} -gt 0 ]] && {
+    (
+      flush_log
+      header
+      flush
+      footer
+    ) > "TestReport-${class}.xml"
+  }
+  init_suite
 }
 
-trap finish EXIT
+trap finish_suite EXIT
 
 while IFS= read -r line; do
   case "$line" in
   "suite "*)
     flush_log
+    finish_suite
     suite_expr="suite (.*)"
     if [[ "$line" =~ $suite_expr ]]; then
       class="${BASH_REMATCH[1]}"
@@ -93,6 +95,7 @@ while IFS= read -r line; do
     name="${line#* $index }"
     ;;
   "ok "* )
+    let count+=1
     expr_ok="ok $index (.*) in ([0-9]+)sec"
     expr_skip="ok $index # skip (.*)"
     if [[ "$line" =~ $expr_skip ]]; then
@@ -108,6 +111,7 @@ while IFS= read -r line; do
     fi
     ;;
   "not ok "* )
+    let count+=1
     let failures+=1
     ;;
   "# "* )

--- a/libexec/bats-format-junit
+++ b/libexec/bats-format-junit
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-header_pattern='[0-9]+\.\.[0-9]+'
 IFS= read -r header
 
 index=0
@@ -32,7 +31,7 @@ pass() {
 
 fail() {
     echo "\
-    <testcase classname=\"${class}\" name=\"${name}\">
+    <testcase classname=\"${class}\" name=\"${name}\" time=\"${test_exec_time}\">
         <failure><![CDATA[$1]]></failure>
     </testcase>\n"
 }
@@ -72,7 +71,7 @@ finish_suite() {
       header
       flush
       footer
-    ) > "TestReport-${class}.xml"
+    ) > "TestReport-${class-case}.xml"
   }
   init_suite
 }
@@ -96,13 +95,14 @@ while IFS= read -r line; do
     ;;
   "ok "* )
     let count+=1
-    expr_ok="ok $index (.*) in ([0-9]+)sec"
+    expr_ok="ok $index .* in ([0-9]+)sec"
     expr_skip="ok $index # skip (.*)"
     if [[ "$line" =~ $expr_skip ]]; then
       let skipped+=1
-      buffer skip "${BASH_REMATCH[2]}"
+      test_exec_time=0
+      buffer skip "${BASH_REMATCH[1]}"
     elif [[ "$line" =~ $expr_ok ]]; then
-      test_exec_time="${BASH_REMATCH[2]}"
+      test_exec_time="${BASH_REMATCH[1]}"
       suitetest_exec_time=$((suitetest_exec_time + test_exec_time))
       buffer pass
     else
@@ -113,6 +113,11 @@ while IFS= read -r line; do
   "not ok "* )
     let count+=1
     let failures+=1
+    expr_notok="not ok $index .* in ([0-9]+)sec"
+    if [[ "$line" =~ $expr_notok ]]; then
+      test_exec_time="${BASH_REMATCH[1]}"
+      suitetest_exec_time=$((suitetest_exec_time + test_exec_time))
+    fi
     ;;
   "# "* )
     log "${line:2}"

--- a/libexec/bats-format-junit
+++ b/libexec/bats-format-junit
@@ -28,19 +28,19 @@ footer() {
 
 
 pass() {
-    echo "    <testcase classname=\"$class\" name=\"$name\"/>\n"
+    echo "    <testcase classname=\"${class}\" name=\"${name}\" time=\"${test_exec_time}\"/>\n"
 }
 
 fail() {
     echo "\
-    <testcase classname=\"$class\" name=\"$name\">
+    <testcase classname=\"${class}\" name=\"${name}\">
         <failure><![CDATA[$1]]></failure>
     </testcase>\n"
 }
 
 skip() {
     echo "\
-    <testcase classname=\"$class\" name=\"$name\">
+    <testcase classname=\"${class}\" name=\"${name}\" time=\"${test_exec_time}\">
         <skipped>$1</skipped>
     </testcase>\n"
 }
@@ -63,20 +63,19 @@ log() {
 
 flush_log() {
   if [[ -n "${_buffer_log}" ]]; then
-		buffer fail "${_buffer_log}"
-		_buffer_log=""
+    buffer fail "${_buffer_log}"
+    _buffer_log=""
   fi
 }
 
 finish() {
-    flush_log
-    header
-		flush
-		footer
+  flush_log
+  header
+  flush
+  footer
 }
 
 trap finish EXIT
-
 
 while IFS= read -r line; do
   case "$line" in
@@ -93,12 +92,17 @@ while IFS= read -r line; do
     name="${line#* $index }"
     ;;
   "ok "* )
-    skip_expr="ok $index # skip (\(([^)]*)\))?"
-    if [[ "$line" =~ $skip_expr ]]; then
+    expr_ok="ok $index (.*) in ([0-9]+)sec"
+    expr_skip="ok $index # skip (.*)"
+    if [[ "$line" =~ $expr_skip ]]; then
       let skipped+=1
       buffer skip "${BASH_REMATCH[2]}"
-    else
+    elif [[ "$line" =~ $expr_ok ]]; then
+      test_exec_time="${BASH_REMATCH[2]}"
       buffer pass
+    else
+      log "Wrong output format: ${line}"
+      let failures+=1
     fi
     ;;
   "not ok "* )
@@ -109,5 +113,4 @@ while IFS= read -r line; do
     ;;
   esac
 done
-
 

--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -39,6 +39,7 @@ begin() {
 
 pass() {
   go_to_column 0
+  set_color 2
   printf " ✓ %s" "$name"
   advance
 }

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -224,7 +224,7 @@ fixtures bats
   [ "${lines[1]}" = 'begin 1 a failing test' ]
   [ "${lines[2]}" = 'not ok 1 a failing test' ]
   [ "${lines[5]}" = 'begin 2 a passing test' ]
-  [ "${lines[6]}" = 'ok 2 a passing test' ]
+  [ "${lines[6]}" = 'ok 2 a passing test in 0sec' ]
 }
 
 @test "pretty and tap formats" {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -150,6 +150,7 @@ fixtures bats
 }
 
 @test "failing test file outside of BATS_CWD" {
+  unset BATS_LIBEXEC BATS_PREFIX BATS_CWD
   cd "$TMP"
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -223,7 +223,7 @@ fixtures bats
   run bats-exec-test -x "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'begin 1 a failing test' ]
-  [ "${lines[2]}" = 'not ok 1 a failing test' ]
+  [ "${lines[2]}" = 'not ok 1 a failing test in 0sec' ]
   [ "${lines[5]}" = 'begin 2 a passing test' ]
   [ "${lines[6]}" = 'ok 2 a passing test in 0sec' ]
 }

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -62,5 +62,5 @@ fixtures suite
   [ "${lines[5]}" = "begin 2 more truth" ]
   [ "${lines[6]}" = "ok 2 more truth in 0sec" ]
   [ "${lines[7]}" = "begin 3 quasi-truth" ]
-  [ "${lines[8]}" = "not ok 3 quasi-truth" ]
+  [ "${lines[8]}" = "not ok 3 quasi-truth in 0sec" ]
 }

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -55,10 +55,12 @@ fixtures suite
   FLUNK=1 run bats-exec-suite -x "$FIXTURE_ROOT/multiple/"*.bats
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
-  [ "${lines[1]}" = "begin 1 truth" ]
-  [ "${lines[2]}" = "ok 1 truth" ]
-  [ "${lines[3]}" = "begin 2 more truth" ]
-  [ "${lines[4]}" = "ok 2 more truth" ]
-  [ "${lines[5]}" = "begin 3 quasi-truth" ]
-  [ "${lines[6]}" = "not ok 3 quasi-truth" ]
+  [ "${lines[1]}" = "suite bats.a" ]
+  [ "${lines[2]}" = "begin 1 truth" ]
+  [ "${lines[3]}" = "ok 1 truth" ]
+  [ "${lines[4]}" = "suite bats.b" ]
+  [ "${lines[5]}" = "begin 2 more truth" ]
+  [ "${lines[6]}" = "ok 2 more truth" ]
+  [ "${lines[7]}" = "begin 3 quasi-truth" ]
+  [ "${lines[8]}" = "not ok 3 quasi-truth" ]
 }

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -57,10 +57,10 @@ fixtures suite
   [ "${lines[0]}" = "1..3" ]
   [ "${lines[1]}" = "suite bats.a" ]
   [ "${lines[2]}" = "begin 1 truth" ]
-  [ "${lines[3]}" = "ok 1 truth" ]
+  [ "${lines[3]}" = "ok 1 truth in 0sec" ]
   [ "${lines[4]}" = "suite bats.b" ]
   [ "${lines[5]}" = "begin 2 more truth" ]
-  [ "${lines[6]}" = "ok 2 more truth" ]
+  [ "${lines[6]}" = "ok 2 more truth in 0sec" ]
   [ "${lines[7]}" = "begin 3 quasi-truth" ]
   [ "${lines[8]}" = "not ok 3 quasi-truth" ]
 }


### PR DESCRIPTION
- Added the parameter --junit to bats which output into JUnit XML format, the purpose was to integrate the report into Jenkins
- I had to add the suite name into the extended report format so I can classify tests by file
- I added --extended parameter to bats command so you can run the test suite once and format the output into several format (ie: pretty for the console and junit into a result.xml file)

Please advise if you see anything to change!
