### PR TITLE
Color passing tests in green

### DIFF
--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -39,6 +39,7 @@ begin() {
 
 pass() {
   go_to_column 0
+  set_color 2
   printf " ✓ %s" "$name"
   advance
 }


### PR DESCRIPTION
This one-line PR colors the passing tests in green, instead of the current white. This is in line with the xUnit series of tools, where we can see red or green, not just red.

Of course, just my two cents :)
