### PR TITLE
Support log file and filtering tests

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -7,7 +7,7 @@ version() {
 
 usage() {
   version
-  echo "Usage: bats [-c] [-p | -t] [-l <file>] <test> [<test> ...]"
+  echo "Usage: bats [-c] [-p | -t] [-l <file>] [-f <pattern>] <test> [<test> ...]"
 }
 
 help() {
@@ -22,6 +22,7 @@ help() {
   echo "  -t, --tap      Show results in TAP format"
   echo "  -v, --version  Display the version number"
   echo "  -l, --logfile  Print logs to specified file"
+  echo "  -f, --filter   Filter test cases by specified pattern"
   echo
   echo "  For more information, see https://github.com/sstephenson/bats"
   echo
@@ -58,7 +59,7 @@ export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"
 
-unset count_flag pretty log_file
+unset count_flag pretty log_file filter
 [ -t 0 ] && [ -t 1 ] && pretty="1"
 [ -n "$CI" ] && pretty=""
 
@@ -117,6 +118,16 @@ while [[ $# -gt 0 ]]; do
         log_file="$2"
         shift
         ;;
+      "-f" | "--filter" )
+        # Bail out if the option is specified in a group or it's not
+        # given a value
+        if [ "$opt_grouped" = "true" ] || [ "$2" = "" ]; then
+            usage >&2
+            exit 1
+        fi
+        filter="$2"
+        shift
+        ;;
       * )
         usage >&2
         exit 1
@@ -133,6 +144,7 @@ if [ -n "$log_file" ]; then
 fi
 
 export BATS_LOG_FILE="$log_file"
+export BATS_FILTER="$filter"
 
 if [ "${#arguments[@]}" -eq 0 ]; then
   usage >&2

--- a/libexec/bats
+++ b/libexec/bats
@@ -7,7 +7,7 @@ version() {
 
 usage() {
   version
-  echo "Usage: bats [-c] [-p | -t] <test> [<test> ...]"
+  echo "Usage: bats [-c] [-p | -t] [-l <file>] <test> [<test> ...]"
 }
 
 help() {
@@ -21,6 +21,7 @@ help() {
   echo "  -p, --pretty   Show results in pretty format (default for terminals)"
   echo "  -t, --tap      Show results in TAP format"
   echo "  -v, --version  Display the version number"
+  echo "  -l, --logfile  Print logs to specified file"
   echo
   echo "  For more information, see https://github.com/sstephenson/bats"
   echo
@@ -57,7 +58,7 @@ export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"
 
-unset count_flag pretty
+unset count_flag pretty log_file
 [ -t 0 ] && [ -t 1 ] && pretty="1"
 [ -n "$CI" ] && pretty=""
 
@@ -106,6 +107,16 @@ while [[ $# -gt 0 ]]; do
       "-p" | "--pretty" )
         pretty="1"
         ;;
+      "-l" | "--logfile" )
+        # Bail out if the option is specified in a group or it's not
+        # given a value
+        if [ "$opt_grouped" = "true" ] || [ "$2" = "" ]; then
+            usage >&2
+            exit 1
+        fi
+        log_file="$2"
+        shift
+        ;;
       * )
         usage >&2
         exit 1
@@ -116,6 +127,12 @@ while [[ $# -gt 0 ]]; do
   shift
   continue
 done
+
+if [ -n "$log_file" ]; then
+    echo -n > $log_file
+fi
+
+export BATS_LOG_FILE="$log_file"
 
 if [ "${#arguments[@]}" -eq 0 ]; then
   usage >&2

--- a/libexec/bats
+++ b/libexec/bats
@@ -57,53 +57,64 @@ export BATS_PREFIX="$(abs_dirname "$BATS_LIBEXEC")"
 export BATS_CWD="$(abs_dirname .)"
 export PATH="$BATS_LIBEXEC:$PATH"
 
-options=()
-arguments=()
-for arg in "$@"; do
-  if [ "${arg:0:1}" = "-" ]; then
-    if [ "${arg:1:1}" = "-" ]; then
-      options[${#options[*]}]="${arg:2}"
-    else
-      index=1
-      while option="${arg:$index:1}"; do
-        [ -n "$option" ] || break
-        options[${#options[*]}]="$option"
-        let index+=1
-      done
-    fi
-  else
-    arguments[${#arguments[*]}]="$arg"
-  fi
-done
-
 unset count_flag pretty
 [ -t 0 ] && [ -t 1 ] && pretty="1"
 [ -n "$CI" ] && pretty=""
 
-for option in "${options[@]}"; do
-  case "$option" in
-  "h" | "help" )
-    help
-    exit 0
-    ;;
-  "v" | "version" )
-    version
-    exit 0
-    ;;
-  "c" | "count" )
-    count_flag="-c"
-    ;;
-  "t" | "tap" )
-    pretty=""
-    ;;
-  "p" | "pretty" )
-    pretty="1"
-    ;;
-  * )
-    usage >&2
-    exit 1
-    ;;
-  esac
+arguments=()
+
+while [[ $# -gt 0 ]]; do
+  arg="$1"
+
+  if [ ! ${arg:0:1} = "-" ]; then
+    arguments[${#arguments[*]}]="$arg"
+    shift
+    continue
+  fi
+
+  options=()
+  pat="^-[a-z][a-z]+"
+  opt_grouped="false" #whether a option is in a group or not
+  if [[ $arg =~ $pat ]]; then
+    index=1
+    while opt="${arg:$index:1}"; do
+      [ -n "$opt" ] || break
+      options[${#options[*]}]="-$opt"
+      let index+=1
+    done
+    opt_grouped="true"
+  else
+    options[${#options[*]}]=$arg
+  fi
+
+  for opt in ${options[@]}; do
+      case $opt in
+      "-h" | "--help" )
+        help
+        exit 0
+        ;;
+      "-v" | "--version" )
+        version
+        exit 0
+        ;;
+      "-c" | "--count" )
+        count_flag="-c"
+        ;;
+      "-t" | "--tap" )
+        pretty=""
+        ;;
+      "-p" | "--pretty" )
+        pretty="1"
+        ;;
+      * )
+        usage >&2
+        exit 1
+        ;;
+      esac
+  done
+
+  shift
+  continue
 done
 
 if [ "${#arguments[@]}" -eq 0 ]; then

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -263,7 +263,10 @@ bats_exit_trap() {
     status=0
   fi
 
-  rm -f "$BATS_OUT"
+  if [ -n "$BATS_OUT_TEMP" ]; then
+    rm -f $BATS_OUT_TEMP
+  fi
+
   exit "$status"
 }
 
@@ -309,7 +312,13 @@ fi
 
 BATS_TMPNAME="$BATS_TMPDIR/bats.$$"
 BATS_PARENT_TMPNAME="$BATS_TMPDIR/bats.$PPID"
-BATS_OUT="${BATS_TMPNAME}.out"
+
+if [ -z "$BATS_LOG_FILE" ]; then
+  BATS_OUT="${BATS_TMPNAME}.out"
+  BATS_OUT_TEMP=$BATS_OUT
+else
+  BATS_OUT=$BATS_LOG_FILE
+fi
 
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -32,6 +32,7 @@ encode_name() {
 tests=()
 index=0
 pattern='^ *@test  *([^ ].*)  *\{ *(.*)$'
+filter=${BATS_FILTER:-.*}
 
 while IFS= read -r line; do
   let index+=1
@@ -40,7 +41,9 @@ while IFS= read -r line; do
     body="${BASH_REMATCH[2]}"
     name="$(eval echo "$quoted_name")"
     encoded_name="$(encode_name "$name")"
-    tests["${#tests[@]}"]="$encoded_name"
+    if [[ $quoted_name =~ $filter ]]; then
+      tests["${#tests[@]}"]="$encoded_name"
+    fi
     echo "${encoded_name}() { bats_test_begin ${quoted_name} ${index}; ${body}"
   else
     printf "%s\n" "$line"


### PR DESCRIPTION
This PR contains three commits which together are intended to support log to a
a specified file and filtering tests based on regex pattern given by user.

commit 734a049e0b9662805273addcaa187e4ea98a4718

```
Support filtering tests

Support filtering tests based on the regex pattern given by user.
A new option named -f (or --filter) is added for this feature.

For example, to run tests whose name contain word foo or Foo:
$ bats --tap --filter '[Ff]oo'
```

commit d7aea2a76a01c7b91484982531a3f0c222b4f475

```
Support logging to specified file

Currently, bats puts logs to a temporary file and removes the file
at the end of the test. This is not convenient for observing the logs.
This commit makes it possible for user to specify a log file and
observe the logs during test or for post test analyzing. A new option
named -l (or --logfile) is added for this function.
```

commit 0d743bc516c2fda4dee1bab610e0b3d8dd062ce7

```
Support command line options that take values

Add support of command line options that take valuea. This paves
way for adding more features like logging to a specified file and
filtering tests based on a pattern given by user.
```

Signed-off-by: Jin Xu jinuxstyle@hotmail.com
