### PR TITLE
Separate stdout and stderr in `run`

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -59,11 +59,11 @@ run() {
   local temp_stdout=$(mktemp -t stdout.XXXXXX)
   local temp_stderr=$(mktemp -t stderr.XXXXXX)
 
-  $("$@" 2> $temp_stderr 1> $temp_stdout)
+  ( "$@" 2> "$temp_stderr" 1> "$temp_stdout" )
   status="$?"
 
-  output_stdout=$( < $temp_stdout)
-  output_stderr=$( < $temp_stderr)
+  output_stdout=$( < "$temp_stdout")
+  output_stderr=$( < "$temp_stderr")
   output="${output_stderr}${output_stdout}"
 
   IFS=$'\n' lines=($output) lines_stdout=($output_stdout) lines_stderr=($output_stderr)

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -55,9 +55,18 @@ run() {
   set +e
   set +E
   set +T
-  output="$("$@" 2>&1)"
+
+  temp_stdout=$(mktemp -t stdout.XXXXXX)
+  temp_stderr=$(mktemp -t stderr.XXXXXX)
+
+  $("$@" 2> $temp_stderr 1> $temp_stdout)
   status="$?"
-  IFS=$'\n' lines=($output)
+
+  output_stdout=$(cat < $temp_stdout)
+  output_stderr=$(cat < $temp_stderr)
+  output="${output_stderr}${output_stdout}"
+
+  IFS=$'\n' lines=($output) lines_stdout=($output_stdout) lines_stderr=($output_stderr)
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -56,14 +56,14 @@ run() {
   set +E
   set +T
 
-  temp_stdout=$(mktemp -t stdout.XXXXXX)
-  temp_stderr=$(mktemp -t stderr.XXXXXX)
+  local temp_stdout=$(mktemp -t stdout.XXXXXX)
+  local temp_stderr=$(mktemp -t stderr.XXXXXX)
 
   $("$@" 2> $temp_stderr 1> $temp_stdout)
   status="$?"
 
-  output_stdout=$(cat < $temp_stdout)
-  output_stderr=$(cat < $temp_stderr)
+  output_stdout=$( < $temp_stdout)
+  output_stderr=$( < $temp_stderr)
   output="${output_stderr}${output_stdout}"
 
   IFS=$'\n' lines=($output) lines_stdout=($output_stdout) lines_stderr=($output_stderr)

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -206,3 +206,26 @@ fixtures bats
   [ "${lines[4]}" = "not ok 4 failing" ]
   [ "${lines[5]}" = "# (in test file $FIXTURE_ROOT/single_line.bats, line 9)" ]
 }
+
+@test "test output_stderr and lines_stderr are populated" {
+  run bats nonexistent
+  [ $status -eq 1 ]
+  [ $(expr "$output_stderr" : ".*does not exist") -ne 0 ]
+  [ "${lines_stdout[0]}" = "" ]
+
+  run bats
+  [ $status -eq 1 ]
+  [ $(expr "${lines_stderr[1]}" : "Usage:") -ne 0 ]
+}
+
+@test "test output_stdout and lines_stdout are populated" {
+  run bats -c "$FIXTURE_ROOT/output.bats"
+  [ $status -eq 0 ]
+  [ "$output_stdout" = "4" ]
+
+  run bats -v
+  [ $status -eq 0 ]
+  [ $(expr "${lines_stdout[0]}" : "Bats [0-9][0-9.]*") -ne 0 ]
+  [ "${lines_stderr[0]}" = "" ]
+  
+}


### PR DESCRIPTION
> Introduces new variables:
>    $output_stdout, $output_stderr, $lines_stdout, $lines_stderr
>    Existing `$output` and `$lines` variables remain.

I found this while looking into #55 and noticed it never made it into a PR. 

@duggan Thanks for the excellent contribution. I hope you don't mind.

@ahippo Was previously tagged in the branch as well.

Any thoughts on merging this @sstephenson? There was already a good bit of discussion about the topic in #55.

This is not my code. I'm just making a PR for code that I believe adds the feature that I would like.
I see it cannot be merged cleanly. I wouldn't mind cleaning it up to get it merged. Let me know.
