### PR TITLE
Switched most occurrences of echo to printf, a bash builtin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ abs_dirname() {
 
 PREFIX="$1"
 if [ -z "$1" ]; then
-  { echo "usage: $0 <prefix>"
-    echo "  e.g. $0 /usr/local"
+  { printf "usage: $0 <prefix>\n"
+    printf "  e.g. $0 /usr/local\n"
   } >&2
   exit 1
 fi
@@ -34,4 +34,4 @@ cp -R "$BATS_ROOT"/libexec/* "$PREFIX"/libexec
 cp "$BATS_ROOT"/man/bats.1 "$PREFIX"/share/man/man1
 cp "$BATS_ROOT"/man/bats.7 "$PREFIX"/share/man/man7
 
-echo "Installed Bats to $PREFIX/bin/bats"
+printf "Installed Bats to $PREFIX/bin/bats\n"

--- a/libexec/bats
+++ b/libexec/bats
@@ -2,28 +2,28 @@
 set -e
 
 version() {
-  echo "Bats 0.4.0"
+  printf "Bats 0.4.0\n"
 }
 
 usage() {
   version
-  echo "Usage: bats [-c] [-p | -t] <test> [<test> ...]"
+  printf "Usage: bats [-c] [-p | -t] <test> [<test> ...]\n"
 }
 
 help() {
   usage
-  echo
-  echo "  <test> is the path to a Bats test file, or the path to a directory"
-  echo "  containing Bats test files."
-  echo
-  echo "  -c, --count    Count the number of test cases without running any tests"
-  echo "  -h, --help     Display this help message"
-  echo "  -p, --pretty   Show results in pretty format (default for terminals)"
-  echo "  -t, --tap      Show results in TAP format"
-  echo "  -v, --version  Display the version number"
-  echo
-  echo "  For more information, see https://github.com/sstephenson/bats"
-  echo
+  printf "\n"
+  printf "  <test> is the path to a Bats test file, or the path to a directory\n"
+  printf "  containing Bats test files.\n"
+  printf "\n"
+  printf "  -c, --count    Count the number of test cases without running any tests\n"
+  printf "  -h, --help     Display this help message\n"
+  printf "  -p, --pretty   Show results in pretty format (default for terminals)\n"
+  printf "  -t, --tap      Show results in TAP format\n"
+  printf "  -v, --version  Display the version number\n"
+  printf "\n"
+  printf "  For more information, see https://github.com/sstephenson/bats\n"
+  printf "\n"
 }
 
 resolve_link() {
@@ -48,8 +48,8 @@ expand_path() {
   { cd "$(dirname "$1")" 2>/dev/null
     local dirname="$PWD"
     cd "$OLDPWD"
-    echo "$dirname/$(basename "$1")"
-  } || echo "$1"
+    printf "$dirname/$(basename "$1")\n"
+  } || printf "$1\n"
 }
 
 BATS_LIBEXEC="$(abs_dirname "$0")"

--- a/libexec/bats-exec-suite
+++ b/libexec/bats-exec-suite
@@ -21,11 +21,11 @@ for filename in "$@"; do
 done
 
 if [ -n "$count_only_flag" ]; then
-  echo "$count"
+  printf "$count\n"
   exit
 fi
 
-echo "1..$count"
+printf "1..$count\n"
 status=0
 offset=0
 for filename in "$@"; do
@@ -36,15 +36,15 @@ for filename in "$@"; do
       case "$line" in
       "begin "* )
         let index+=1
-        echo "${line/ $index / $(($offset + $index)) }"
+        printf "${line/ $index / $(($offset + $index)) }\n"
         ;;
       "ok "* | "not ok "* )
         [ -n "$extended_syntax_flag" ] || let index+=1
-        echo "${line/ $index / $(($offset + $index)) }"
+        printf "${line/ $index / $(($offset + $index)) }\n"
         [ "${line:0:6}" != "not ok" ] || status=1
         ;;
       * )
-        echo "$line"
+        printf "$line\n"
         ;;
       esac
     done

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -17,10 +17,10 @@ fi
 
 BATS_TEST_FILENAME="$1"
 if [ -z "$BATS_TEST_FILENAME" ]; then
-  printf "usage: bats-exec <filename>\n" >&2
+  echo "usage: bats-exec <filename>" >&2
   exit 1
 elif [ ! -f "$BATS_TEST_FILENAME" ]; then
-  printf "bats: $BATS_TEST_FILENAME does not exist\n" >&2
+  echo "bats: $BATS_TEST_FILENAME does not exist" >&2
   exit 1
 else
   shift
@@ -40,7 +40,7 @@ load() {
   fi
 
   [ -f "$filename" ] || {
-    printf "bats: $filename does not exist\n" >&2
+    echo "bats: $filename does not exist" >&2
     exit 1
   }
 
@@ -82,7 +82,7 @@ skip() {
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
   if [ -n "$BATS_EXTENDED_SYNTAX" ]; then
-    printf "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION\n" >&3
+    echo "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
   fi
   setup
 }
@@ -128,14 +128,14 @@ bats_print_stack_trace() {
     local lineno="$(bats_frame_lineno "$frame")"
 
     if [ $index -eq 1 ]; then
-      printf -n "# (\n"
+      printf "# ("
     else
-      printf -n "#  \n"
+      printf "#  "
     fi
 
     local fn="$(bats_frame_function "$frame")"
     if [ "$fn" != "$BATS_TEST_NAME" ]; then
-      printf -n "from function \`$fn' \n"
+      printf "from function \`$fn' "
     fi
 
     if [ $index -eq $count ]; then
@@ -156,7 +156,7 @@ bats_print_failed_command() {
 
   local failed_line="$(bats_extract_line "$filename" "$lineno")"
   local failed_command="$(bats_strip_string "$failed_line")"
-  printf -n "#   \`${failed_command}' \n"
+  printf "#   \`${failed_command}' "
 
   if [ $status -eq 1 ]; then
     printf "failed\n"
@@ -198,7 +198,7 @@ bats_extract_line() {
 
 bats_strip_string() {
   local string="$1"
-  echo "%s" "$string" | sed -e "s/^[ "$'\t'"]*//" -e "s/[ "$'\t'"]*$//"
+  printf "%s" "$string" | sed -e "s/^[ "$'\t'"]*//" -e "s/[ "$'\t'"]*$//"
 }
 
 bats_trim_filename() {
@@ -313,7 +313,7 @@ BATS_OUT="${BATS_TMPNAME}.out"
 
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
-  { tr -d '\r' < "$BATS_TEST_FILENAME"; printf "\n"; } | bats-preprocess > "$BATS_TEST_SOURCE"
+  { tr -d '\r' < "$BATS_TEST_FILENAME"; echo; } | bats-preprocess > "$BATS_TEST_SOURCE"
   trap "bats_cleanup_preprocessed_source" err exit
   trap "bats_cleanup_preprocessed_source; exit 1" int
 }

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -17,10 +17,10 @@ fi
 
 BATS_TEST_FILENAME="$1"
 if [ -z "$BATS_TEST_FILENAME" ]; then
-  echo "usage: bats-exec <filename>" >&2
+  printf "usage: bats-exec <filename>\n" >&2
   exit 1
 elif [ ! -f "$BATS_TEST_FILENAME" ]; then
-  echo "bats: $BATS_TEST_FILENAME does not exist" >&2
+  printf "bats: $BATS_TEST_FILENAME does not exist\n" >&2
   exit 1
 else
   shift
@@ -40,7 +40,7 @@ load() {
   fi
 
   [ -f "$filename" ] || {
-    echo "bats: $filename does not exist" >&2
+    printf "bats: $filename does not exist\n" >&2
     exit 1
   }
 
@@ -82,7 +82,7 @@ skip() {
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
   if [ -n "$BATS_EXTENDED_SYNTAX" ]; then
-    echo "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    printf "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION\n" >&3
   fi
   setup
 }
@@ -128,20 +128,20 @@ bats_print_stack_trace() {
     local lineno="$(bats_frame_lineno "$frame")"
 
     if [ $index -eq 1 ]; then
-      echo -n "# ("
+      printf -n "# (\n"
     else
-      echo -n "#  "
+      printf -n "#  \n"
     fi
 
     local fn="$(bats_frame_function "$frame")"
     if [ "$fn" != "$BATS_TEST_NAME" ]; then
-      echo -n "from function \`$fn' "
+      printf -n "from function \`$fn' \n"
     fi
 
     if [ $index -eq $count ]; then
-      echo "in test file $filename, line $lineno)"
+      printf "in test file $filename, line $lineno)\n"
     else
-      echo "in file $filename, line $lineno,"
+      printf "in file $filename, line $lineno,\n"
     fi
 
     let index+=1
@@ -156,26 +156,26 @@ bats_print_failed_command() {
 
   local failed_line="$(bats_extract_line "$filename" "$lineno")"
   local failed_command="$(bats_strip_string "$failed_line")"
-  echo -n "#   \`${failed_command}' "
+  printf -n "#   \`${failed_command}' \n"
 
   if [ $status -eq 1 ]; then
-    echo "failed"
+    printf "failed\n"
   else
-    echo "failed with status $status"
+    printf "failed with status $status\n"
   fi
 }
 
 bats_frame_lineno() {
   local frame="$1"
   local lineno="${frame%% *}"
-  echo "$lineno"
+  printf "$lineno\n"
 }
 
 bats_frame_function() {
   local frame="$1"
   local rest="${frame#* }"
   local fn="${rest%% *}"
-  echo "$fn"
+  printf "$fn\n"
 }
 
 bats_frame_filename() {
@@ -184,9 +184,9 @@ bats_frame_filename() {
   local filename="${rest#* }"
 
   if [ "$filename" = "$BATS_TEST_SOURCE" ]; then
-    echo "$BATS_TEST_FILENAME"
+    printf "$BATS_TEST_FILENAME\n"
   else
-    echo "$filename"
+    printf "$filename\n"
   fi
 }
 
@@ -198,7 +198,7 @@ bats_extract_line() {
 
 bats_strip_string() {
   local string="$1"
-  printf "%s" "$string" | sed -e "s/^[ "$'\t'"]*//" -e "s/[ "$'\t'"]*$//"
+  echo "%s" "$string" | sed -e "s/^[ "$'\t'"]*//" -e "s/[ "$'\t'"]*$//"
 }
 
 bats_trim_filename() {
@@ -206,9 +206,9 @@ bats_trim_filename() {
   local length="${#BATS_CWD}"
 
   if [ "${filename:0:length+1}" = "${BATS_CWD}/" ]; then
-    echo "${filename:length+1}"
+    printf "${filename:length+1}\n"
   else
-    echo "$filename"
+    printf "$filename\n"
   fi
 }
 
@@ -253,13 +253,13 @@ bats_exit_trap() {
   fi
 
   if [ -z "$BATS_TEST_COMPLETED" ] || [ -z "$BATS_TEARDOWN_COMPLETED" ]; then
-    echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    printf "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION\n" >&3
     bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
     bats_print_failed_command "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" "$BATS_ERROR_STATUS" >&3
     sed -e "s/^/# /" < "$BATS_OUT" >&3
     status=1
   else
-    echo "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}" >&3
+    printf "ok ${BATS_TEST_NUMBER}${skipped} ${BATS_TEST_DESCRIPTION}\n" >&3
     status=0
   fi
 
@@ -268,7 +268,7 @@ bats_exit_trap() {
 }
 
 bats_perform_tests() {
-  echo "1..$#"
+  printf "1..$#\n"
   test_number=1
   status=0
   for test_name in "$@"; do
@@ -283,7 +283,7 @@ bats_perform_test() {
   if [ "$(type -t "$BATS_TEST_NAME" || true)" = "function" ]; then
     BATS_TEST_NUMBER="$2"
     if [ -z "$BATS_TEST_NUMBER" ]; then
-      echo "1..1"
+      printf "1..1\n"
       BATS_TEST_NUMBER="1"
     fi
 
@@ -296,7 +296,7 @@ bats_perform_test() {
     BATS_TEST_COMPLETED=1
 
   else
-    echo "bats: unknown test name \`$BATS_TEST_NAME'" >&2
+    printf "bats: unknown test name \`$BATS_TEST_NAME'\n" >&2
     exit 1
   fi
 }
@@ -313,7 +313,7 @@ BATS_OUT="${BATS_TMPNAME}.out"
 
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
-  { tr -d '\r' < "$BATS_TEST_FILENAME"; echo; } | bats-preprocess > "$BATS_TEST_SOURCE"
+  { tr -d '\r' < "$BATS_TEST_FILENAME"; printf "\n"; } | bats-preprocess > "$BATS_TEST_SOURCE"
   trap "bats_cleanup_preprocessed_source" err exit
   trap "bats_cleanup_preprocessed_source; exit 1" int
 }
@@ -336,7 +336,7 @@ if [ "$#" -eq 0 ]; then
   bats_evaluate_preprocessed_source
 
   if [ -n "$BATS_COUNT_ONLY" ]; then
-    echo "${#BATS_TEST_NAMES[@]}"
+    printf "${#BATS_TEST_NAMES[@]}\n"
   else
     bats_perform_tests "${BATS_TEST_NAMES[@]}"
   fi

--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -16,7 +16,7 @@ if [[ "$header" =~ $header_pattern ]]; then
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
-  printf "%s\n" "$header"
+  printf "%s" "$header\n"
   exec cat
 fi
 

--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -16,7 +16,7 @@ if [[ "$header" =~ $header_pattern ]]; then
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
-  printf "%s" "$header\n"
+  printf "%s\n" "$header"
   exec cat
 fi
 
@@ -99,14 +99,14 @@ clear_to_end_of_line() {
 
 advance() {
   clear_to_end_of_line
-  echo
+  printf "\n"
   clear_color
 }
 
 set_color() {
   local color="$1"
   local weight="$2"
-  printf "\x1B[%d;%dm" $(( 30 + $color )) "$( [ "$weight" = "bold" ] && echo 1 || echo 22 )"
+  printf "\x1B[%d;%dm" $(( 30 + $color )) "$( [ "$weight" = "bold" ] && printf "1\n" || printf "22\n" )"
 }
 
 clear_color() {
@@ -114,7 +114,7 @@ clear_color() {
 }
 
 plural() {
-  [ "$1" -eq 1 ] || echo "s"
+  [ "$1" -eq 1 ] || printf "s\n"
 }
 
 _buffer=""

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -26,7 +26,7 @@ encode_name() {
     done
   fi
 
-  echo "$result"
+  printf "$result\n"
 }
 
 tests=()
@@ -48,5 +48,5 @@ while IFS= read -r line; do
 done
 
 for test_name in "${tests[@]}"; do
-  echo "bats_test_function ${test_name}"
+  printf "bats_test_function ${test_name}\n"
 done

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+#!../libexec/bats
 
 load test_helper
 fixtures bats

--- a/test/fixtures/bats/loop_keep_IFS.bats
+++ b/test/fixtures/bats/loop_keep_IFS.bats
@@ -4,7 +4,7 @@ loop_func() {
   local d
 
   for d in $search ; do
-    echo $d
+    printf "$d\n"
   done
 }
 

--- a/test/fixtures/bats/output.bats
+++ b/test/fixtures/bats/output.bats
@@ -1,19 +1,19 @@
 @test "success writing to stdout" {
-  echo "success stdout 1"
-  echo "success stdout 2"
+  printf "success stdout 1\n"
+  printf "success stdout 2\n"
 }
 
 @test "success writing to stderr" {
-  echo "success stderr" >&2
+  printf "success stderr\n" >&2
 }
 
 @test "failure writing to stdout" {
-  echo "failure stdout 1"
-  echo "failure stdout 2"
+  printf "failure stdout 1\n"
+  printf "failure stdout 2\n"
   false
 }
 
 @test "failure writing to stderr" {
-  echo "failure stderr" >&2
+  printf "failure stderr\n" >&2
   false
 }

--- a/test/fixtures/bats/setup.bats
+++ b/test/fixtures/bats/setup.bats
@@ -1,7 +1,7 @@
 LOG="$TMP/setup.log"
 
 setup() {
-  echo "$BATS_TEST_NAME" >> "$LOG"
+  printf "$BATS_TEST_NAME\n" >> "$LOG"
 }
 
 @test "one" {

--- a/test/fixtures/bats/teardown.bats
+++ b/test/fixtures/bats/teardown.bats
@@ -1,7 +1,7 @@
 LOG="$TMP/teardown.log"
 
 teardown() {
-  echo "$BATS_TEST_NAME" >> "$LOG"
+  printf "$BATS_TEST_NAME\n" >> "$LOG"
 }
 
 @test "one" {

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+#!../libexec/bats
 
 load test_helper
 fixtures suite
@@ -30,25 +30,25 @@ fixtures suite
   run bats "$FIXTURE_ROOT/multiple"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
-  echo "$output" | grep "^ok . truth"
-  echo "$output" | grep "^ok . more truth"
-  echo "$output" | grep "^ok . quasi-truth"
+  printf "$output\n" | grep "^ok . truth"
+  printf "$output\n" | grep "^ok . more truth"
+  printf "$output\n" | grep "^ok . quasi-truth"
 }
 
 @test "a failing test in a suite results in an error exit code" {
   FLUNK=1 run bats "$FIXTURE_ROOT/multiple"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
-  echo "$output" | grep "^not ok . quasi-truth"
+  printf "$output\n" | grep "^not ok . quasi-truth"
 }
 
 @test "running an ad-hoc suite by specifying multiple test files" {
   run bats "$FIXTURE_ROOT/multiple/a.bats" "$FIXTURE_ROOT/multiple/b.bats"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
-  echo "$output" | grep "^ok . truth"
-  echo "$output" | grep "^ok . more truth"
-  echo "$output" | grep "^ok . quasi-truth"
+  printf "$output\n" | grep "^ok . truth"
+  printf "$output\n" | grep "^ok . more truth"
+  printf "$output\n" | grep "^ok . quasi-truth"
 }
 
 @test "extended syntax in suite" {


### PR DESCRIPTION
I ran the pgporada/bats/test/bats.bats 10 times and received the following average time
```
Average:
real 2.388 user 0.533 sys 0.203
```

Compared to sstephenson/bats/test/bats.bats 10 times
```
Average:
real 2.457 user 0.537 sys 0.203
```

It's marginally faster, but it does use more bash features.

All tests are passing
```
$ ./bats.bats
 ✓ no arguments prints usage instructions
 ✓ -v and --version print version number
 ✓ -h and --help print help
 ✓ invalid filename prints an error
 ✓ empty test file runs zero tests
 ✓ one passing test
 ✓ summary passing tests
 ✓ summary passing and skipping tests
 ✓ summary passing and failing tests
 ✓ summary passing, failing and skipping tests
 ✓ one failing test
 ✓ one failing and one passing test
 ✓ failing test with significant status
 ✓ failing helper function logs the test case's line number
 ✓ test environments are isolated
 ✓ setup is run once before each test
 ✓ teardown is run once after each test, even if it fails
 ✓ setup failure
 ✓ passing test with teardown failure
 ✓ failing test with teardown failure
 ✓ teardown failure with significant status
 ✓ failing test file outside of BATS_CWD
 ✓ load sources scripts relative to the current test file
 ✓ load aborts if the specified script does not exist
 ✓ load sources scripts by absolute path
 ✓ load aborts if the script, specified by an absolute path, does not exist
 ✓ output is discarded for passing tests and printed for failing tests
 ✓ -c prints the number of tests
 ✓ dash-e is not mangled on beginning of line
 ✓ dos line endings are stripped before testing
 ✓ test file without trailing newline
 ✓ skipped tests
 ✓ extended syntax
 ✓ pretty and tap formats
 ✓ pretty formatter bails on invalid tap
 ✓ single-line tests
 ✓ testing IFS not modified by run

37 tests, 0 failures
```
and
```
$ ./suite.bats 
 ✓ running a suite with no test files
 ✓ running a suite with one test file
 ✓ counting tests in a suite
 ✓ aggregated output of multiple tests in a suite
 ✓ a failing test in a suite results in an error exit code
 ✓ running an ad-hoc suite by specifying multiple test files
 ✓ extended syntax in suite

7 tests, 0 failures
```