### PR TITLE
Allow `load`ing files that don't end in .bash

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 version() {
   echo "Bats 0.4.0"

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -35,8 +35,11 @@ load() {
 
   if [ "${name:0:1}" = "/" ]; then
     filename="${name}"
-  else
-    filename="$BATS_TEST_DIRNAME/${name}.bash"
+  else if [ -f "$BATS_TEST_DIRNAME/${name}" ] ; then
+      filename="$BATS_TEST_DIRNAME/${name}"
+      else
+      filename="$BATS_TEST_DIRNAME/${name}.bash"
+    fi
   fi
 
   [ -f "$filename" ] || {


### PR DESCRIPTION
Sometimes you're using scripts with extensions other than .bash. If you explicitly say `load file.extension` without this patch, it will try to load `file.extension.bash` and error if it does not exist.