### PR TITLE
Lines splitting now does not glob; closes sstephenson/bats#207

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -58,7 +58,7 @@ run() {
   output="$("$@" 2>&1)"
   status="$?"
   oldIFS=$IFS
-  IFS=$'\n' lines=($output)
+  IFS=$'\n' readarray -t lines <<< "$output"
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -43,25 +43,25 @@ fixtures bats
 @test "summary passing tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing.bats
   [ $status -eq 0 ]
-  [ "${lines[1]}" = "1 test, 0 failures" ]
+  [ "${lines[2]}" = "1 test, 0 failures" ]
 }
 
 @test "summary passing and skipping tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_and_skipping.bats
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "2 tests, 0 failures, 1 skipped" ]
+  [ "${lines[3]}" = "2 tests, 0 failures, 1 skipped" ]
 }
 
 @test "summary passing and failing tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/failing_and_passing.bats
   [ $status -eq 0 ]
-  [ "${lines[4]}" = "2 tests, 1 failure" ]
+  [ "${lines[5]}" = "2 tests, 1 failure" ]
 }
 
 @test "summary passing, failing and skipping tests" {
   run filter_control_sequences bats -p $FIXTURE_ROOT/passing_failing_and_skipping.bats
   [ $status -eq 0 ]
-  [ "${lines[5]}" = "3 tests, 1 failure, 1 skipped" ]
+  [ "${lines[6]}" = "3 tests, 1 failure, 1 skipped" ]
 }
 
 @test "one failing test" {
@@ -261,4 +261,10 @@ fixtures bats
   run bats "$FIXTURE_ROOT/loop_keep_IFS.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 loop_func" ]
+}
+
+@test "testing quoting in lines splitting works" {
+  run echo '*'
+  [ "${lines[0]}" = "*" ]
+  [ "$output" = "*" ]
 }


### PR DESCRIPTION
To avoid problems from globbing, now lines splitting is done via `readarray` bash builtin.