### PR TITLE
Fix macOS/Bash 3.2 breakage; eliminate subshells from exec-test, preprocess

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -101,16 +101,15 @@ bats_capture_stack_trace() {
   local teardown_pattern=" teardown $BATS_TEST_SOURCE"
 
   local frame
-  local index=1
+  local i
 
-  while frame="$(caller "$index")"; do
+  for ((i=2; i != ${#FUNCNAME[@]}; ++i)); do
+    frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} ${BASH_SOURCE[$i]}"
     BATS_CURRENT_STACK_TRACE["${#BATS_CURRENT_STACK_TRACE[@]}"]="$frame"
     if [[ "$frame" = *"$test_pattern"     || \
           "$frame" = *"$setup_pattern"    || \
           "$frame" = *"$teardown_pattern" ]]; then
       break
-    else
-      let index+=1
     fi
   done
 

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -26,7 +26,7 @@ else
   shift
 fi
 
-BATS_TEST_DIRNAME="$(dirname "$BATS_TEST_FILENAME")"
+BATS_TEST_DIRNAME="${BATS_TEST_FILENAME%/*}"
 BATS_TEST_NAMES=()
 
 load() {

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -327,7 +327,7 @@ BATS_OUT="${BATS_TMPNAME}.out"
 
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
-  { tr -d '\r' < "$BATS_TEST_FILENAME"; echo; } | bats-preprocess > "$BATS_TEST_SOURCE"
+  . bats-preprocess <<< "$(< "$BATS_TEST_FILENAME")"$'\n' > "$BATS_TEST_SOURCE"
   trap "bats_cleanup_preprocessed_source" err exit
   trap "bats_cleanup_preprocessed_source; exit 1" int
 }

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -218,13 +218,22 @@ bats_debug_trap() {
   fi
 }
 
+# When running under Bash 3.2.57(1)-release on macOS, the `ERR` trap may not
+# always fire, but the `EXIT` trap will. For this reason we call it at the very
+# beginning of `bats_teardown_trap` (the `DEBUG` trap for the call will move
+# `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the value
+# of `$?` before taking other actions.
 bats_error_trap() {
-  BATS_ERROR_STATUS="$?"
-  BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
-  trap - debug
+  local status="$?"
+  if [[ "$status" -ne '0' ]]; then
+    BATS_ERROR_STATUS="$status"
+    BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
+    trap - debug
+  fi
 }
 
 bats_teardown_trap() {
+  bats_error_trap
   trap "bats_exit_trap" exit
   local status=0
   teardown >>"$BATS_OUT" 2>&1 || status="$?"

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -127,7 +127,7 @@ bats_print_stack_trace() {
 
   for frame in "$@"; do
     bats_frame_filename "$frame" 'filename'
-    filename="$(bats_trim_filename "$filename")"
+    bats_trim_filename "$filename" 'filename'
     bats_frame_lineno "$frame" 'lineno'
 
     if [ $index -eq 1 ]; then
@@ -203,13 +203,10 @@ bats_strip_string() {
 }
 
 bats_trim_filename() {
-  local filename="$1"
-  local length="${#BATS_CWD}"
-
-  if [ "${filename:0:length+1}" = "${BATS_CWD}/" ]; then
-    echo "${filename:length+1}"
+  if [[ "$1" =~ ^${BATS_CWD}/ ]]; then
+    printf -v "$2" '%s' "${1#$BATS_CWD/}"
   else
-    echo "$filename"
+    printf -v "$2" '%s' "$1"
   fi
 }
 

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -162,8 +162,10 @@ bats_print_failed_command() {
   bats_frame_lineno "$frame" 'lineno'
 
   local failed_line="$(bats_extract_line "$filename" "$lineno")"
-  local failed_command="$(bats_strip_string "$failed_line")"
-  echo -n "#   \`${failed_command}' "
+  local failed_command
+
+  bats_strip_string "$failed_line" 'failed_command'
+  printf '%s' "#   \`${failed_command}' "
 
   if [ $status -eq 1 ]; then
     echo "failed"
@@ -198,8 +200,8 @@ bats_extract_line() {
 }
 
 bats_strip_string() {
-  local string="$1"
-  printf "%s" "$string" | sed -e "s/^[ "$'\t'"]*//" -e "s/[ "$'\t'"]*$//"
+  [[ "$1" =~ ^[[:space:]]*(.*)[[:space:]]*$ ]]
+  printf -v "$2" '%s' "${BASH_REMATCH[1]}"
 }
 
 bats_trim_filename() {

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -39,10 +39,10 @@ load() {
     filename="$BATS_TEST_DIRNAME/${name}.bash"
   fi
 
-  [ -f "$filename" ] || {
+  if [[ ! -f "$filename" ]]; then
     echo "bats: $filename does not exist" >&2
     exit 1
-  }
+  fi
 
   source "${filename}"
 }

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -157,13 +157,12 @@ bats_print_failed_command() {
   local status="$2"
   local filename
   local lineno
+  local failed_line
+  local failed_command
 
   bats_frame_filename "$frame" 'filename'
   bats_frame_lineno "$frame" 'lineno'
-
-  local failed_line="$(bats_extract_line "$filename" "$lineno")"
-  local failed_command
-
+  bats_extract_line "$filename" "$lineno" 'failed_line'
   bats_strip_string "$failed_line" 'failed_command'
   printf '%s' "#   \`${failed_command}' "
 
@@ -194,9 +193,15 @@ bats_frame_filename() {
 }
 
 bats_extract_line() {
-  local filename="$1"
-  local lineno="$2"
-  sed -n "${lineno}p" "$filename"
+  local __bats_extract_line_line
+  local __bats_extract_line_index='0'
+
+  while IFS= read -r __bats_extract_line_line; do
+    if [[ "$((++__bats_extract_line_index))" -eq "$2" ]]; then
+      printf -v "$3" '%s' "${__bats_extract_line_line%$'\r'}"
+      break
+    fi
+  done <"$1"
 }
 
 bats_strip_string() {

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -114,18 +114,21 @@ bats_capture_stack_trace() {
     fi
   done
 
-  BATS_SOURCE="$(bats_frame_filename "${BATS_CURRENT_STACK_TRACE[0]}")"
-  BATS_LINENO="$(bats_frame_lineno "${BATS_CURRENT_STACK_TRACE[0]}")"
+  bats_frame_filename "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_SOURCE'
+  bats_frame_lineno "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_LINENO'
 }
 
 bats_print_stack_trace() {
   local frame
   local index=1
   local count="${#@}"
+  local filename
+  local lineno
 
   for frame in "$@"; do
-    local filename="$(bats_trim_filename "$(bats_frame_filename "$frame")")"
-    local lineno="$(bats_frame_lineno "$frame")"
+    bats_frame_filename "$frame" 'filename'
+    filename="$(bats_trim_filename "$filename")"
+    bats_frame_lineno "$frame" 'lineno'
 
     if [ $index -eq 1 ]; then
       echo -n "# ("
@@ -133,7 +136,8 @@ bats_print_stack_trace() {
       echo -n "#  "
     fi
 
-    local fn="$(bats_frame_function "$frame")"
+    local fn
+    bats_frame_function "$frame" 'fn'
     if [ "$fn" != "$BATS_TEST_NAME" ]; then
       echo -n "from function \`$fn' "
     fi
@@ -151,8 +155,11 @@ bats_print_stack_trace() {
 bats_print_failed_command() {
   local frame="$1"
   local status="$2"
-  local filename="$(bats_frame_filename "$frame")"
-  local lineno="$(bats_frame_lineno "$frame")"
+  local filename
+  local lineno
+
+  bats_frame_filename "$frame" 'filename'
+  bats_frame_lineno "$frame" 'lineno'
 
   local failed_line="$(bats_extract_line "$filename" "$lineno")"
   local failed_command="$(bats_strip_string "$failed_line")"
@@ -166,12 +173,12 @@ bats_print_failed_command() {
 }
 
 bats_frame_lineno() {
-  printf '%s\n' "${1%% *}"
+  printf -v "$2" '%s' "${1%% *}"
 }
 
 bats_frame_function() {
   local __bff_function="${1#* }"
-  printf '%s\n' "${__bff_function%% *}"
+  printf -v "$2" '%s' "${__bff_function%% *}"
 }
 
 bats_frame_filename() {
@@ -181,7 +188,7 @@ bats_frame_filename() {
   if [ "$__bff_filename" = "$BATS_TEST_SOURCE" ]; then
     __bff_filename="$BATS_TEST_FILENAME"
   fi
-  printf '%s\n' "$__bff_filename"
+  printf -v "$2" '%s' "$__bff_filename"
 }
 
 bats_extract_line() {

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -289,7 +289,7 @@ bats_perform_tests() {
 
 bats_perform_test() {
   BATS_TEST_NAME="$1"
-  if [ "$(type -t "$BATS_TEST_NAME" || true)" = "function" ]; then
+  if declare -F "$BATS_TEST_NAME" >/dev/null; then
     BATS_TEST_NUMBER="$2"
     if [ -z "$BATS_TEST_NUMBER" ]; then
       echo "1..1"

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -166,28 +166,22 @@ bats_print_failed_command() {
 }
 
 bats_frame_lineno() {
-  local frame="$1"
-  local lineno="${frame%% *}"
-  echo "$lineno"
+  printf '%s\n' "${1%% *}"
 }
 
 bats_frame_function() {
-  local frame="$1"
-  local rest="${frame#* }"
-  local fn="${rest%% *}"
-  echo "$fn"
+  local __bff_function="${1#* }"
+  printf '%s\n' "${__bff_function%% *}"
 }
 
 bats_frame_filename() {
-  local frame="$1"
-  local rest="${frame#* }"
-  local filename="${rest#* }"
+  local __bff_filename="${1#* }"
+  __bff_filename="${__bff_filename#* }"
 
-  if [ "$filename" = "$BATS_TEST_SOURCE" ]; then
-    echo "$BATS_TEST_FILENAME"
-  else
-    echo "$filename"
+  if [ "$__bff_filename" = "$BATS_TEST_SOURCE" ]; then
+    __bff_filename="$BATS_TEST_FILENAME"
   fi
+  printf '%s\n' "$__bff_filename"
 }
 
 bats_extract_line() {

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -33,18 +33,18 @@ encode_name() {
 
 tests=()
 index=0
-pattern='^ *@test  *([^ ].*)  *\{ *(.*)$'
+pattern='^ *@test +(.+) +\{ *(.*)$'
 
 while IFS= read -r line; do
   line="${line//$'\r'}"
   let index+=1
   if [[ "$line" =~ $pattern ]]; then
-    quoted_name="${BASH_REMATCH[1]}"
+    name="${BASH_REMATCH[1]#[\'\"]}"
+    name="${name%[\'\"]}"
     body="${BASH_REMATCH[2]}"
-    name="$(eval echo "$quoted_name")"
     encode_name "$name" 'encoded_name'
     tests["${#tests[@]}"]="$encoded_name"
-    echo "${encoded_name}() { bats_test_begin ${quoted_name} ${index}; ${body}"
+    echo "${encoded_name}() { bats_test_begin \"${name}\" ${index}; ${body}"
   else
     printf "%s\n" "$line"
   fi

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -4,6 +4,7 @@ set -e
 encode_name() {
   local name="$1"
   local result="test_"
+  local hex_code
 
   if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
     name="${name//_/-5f}"
@@ -21,12 +22,13 @@ encode_name() {
       elif [[ "$char" =~ [[:alnum:]] ]]; then
         result+="$char"
       else
-        result+="$(printf -- "-%02x" \'"$char")"
+        printf -v 'hex_code' -- "-%02x" \'"$char"
+        result+="$hex_code"
       fi
     done
   fi
 
-  echo "$result"
+  printf -v "$2" '%s' "$result"
 }
 
 tests=()
@@ -40,7 +42,7 @@ while IFS= read -r line; do
     quoted_name="${BASH_REMATCH[1]}"
     body="${BASH_REMATCH[2]}"
     name="$(eval echo "$quoted_name")"
-    encoded_name="$(encode_name "$name")"
+    encode_name "$name" 'encoded_name'
     tests["${#tests[@]}"]="$encoded_name"
     echo "${encoded_name}() { bats_test_begin ${quoted_name} ${index}; ${body}"
   else

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -34,6 +34,7 @@ index=0
 pattern='^ *@test  *([^ ].*)  *\{ *(.*)$'
 
 while IFS= read -r line; do
+  line="${line//$'\r'}"
   let index+=1
   if [[ "$line" =~ $pattern ]]; then
     quoted_name="${BASH_REMATCH[1]}"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -262,3 +262,17 @@ fixtures bats
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 loop_func" ]
 }
+
+@test "expand variables in test name" {
+  SUITE='test/suite' run bats "$FIXTURE_ROOT/expand_var_in_test_name.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 test/suite: test with variable in name" ]
+}
+
+@test "handle quoted and unquoted test names" {
+  run bats "$FIXTURE_ROOT/quoted_and_unquoted_test_names.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 single-quoted name" ]
+  [ "${lines[2]}" = "ok 2 double-quoted name" ]
+  [ "${lines[3]}" = "ok 3 unquoted" ]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -274,5 +274,5 @@ fixtures bats
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 single-quoted name" ]
   [ "${lines[2]}" = "ok 2 double-quoted name" ]
-  [ "${lines[3]}" = "ok 3 unquoted" ]
+  [ "${lines[3]}" = "ok 3 unquoted name" ]
 }

--- a/test/fixtures/bats/expand_var_in_test_name.bats
+++ b/test/fixtures/bats/expand_var_in_test_name.bats
@@ -1,0 +1,3 @@
+@test "$SUITE: test with variable in name" {
+  true
+}

--- a/test/fixtures/bats/quoted_and_unquoted_test_names.bats
+++ b/test/fixtures/bats/quoted_and_unquoted_test_names.bats
@@ -1,0 +1,11 @@
+@test 'single-quoted name' {
+  true
+}
+
+@test "double-quoted name" {
+  true
+}
+
+@test unquoted {
+  true
+}

--- a/test/fixtures/bats/quoted_and_unquoted_test_names.bats
+++ b/test/fixtures/bats/quoted_and_unquoted_test_names.bats
@@ -6,6 +6,6 @@
   true
 }
 
-@test unquoted {
+@test unquoted name {
   true
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,6 +1,6 @@
 fixtures() {
   FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures/$1"
-  RELATIVE_FIXTURE_ROOT="$(bats_trim_filename "$FIXTURE_ROOT")"
+  bats_trim_filename "$FIXTURE_ROOT" 'RELATIVE_FIXTURE_ROOT'
 }
 
 setup() {


### PR DESCRIPTION
These changes produce some substantial performance benefits across all platforms, but most especially on Windows. I'm using them in the mainline of my own project as of https://github.com/mbland/go-script-bash/pull/165 ([Travis CI results](https://travis-ci.org/mbland/go-script-bash/builds/202009148), [Coveralls results](https://coveralls.io/builds/10171598)).

If this PR contains too many changes at once, I'm happy to break it up. Also, I just noticed that this PR addresses #98, without even having looked at #122 before.

cc: @ztombol @stroupaloop

### macOS fix

The first commit in this set fixes the three existing tests that failed for Bash 3.2.57(1)-release, the default version for macOS 10.12.3 and other earlier versions of macOS and OS X. This was due to the `ERR` trap not always firing as it should; adding some guard logic to `bats_error_trap` before calling it from `bats_teardown_trap` resolved the issue.

### Performance impact on Bats's own test suite

The remaining commits methodically eliminate subshells to improve overall test performance, especially those spawned by `bats_capture_stack_trace` via `bats_debug_trap`.

Under Bash 3.2.57(1)-release on a MacBook Pro with a 2.9GHz Intel Core i5 CPU and 8GB 1867MHz DDR3 RAM, the timing for the original set of tests (which don't include the four test name-related cases added by one of the later commits in this series) run via `bin/bats test/` went from:

```
  44 tests, 0 failures

  real    0m7.565s
  user    0m3.664s
  sys     0m3.368s
```

to:

```
  real    0m4.319s
  user    0m2.559s
  sys     0m1.454s
```

### Performance impact on a large Bats test suite

In my https://github.com/mbland/go-script-bash project, I'd already optimized the tests to disable Bats stack trace collection almost as much as possible, bringing the time for the full `./go test` suite on the same machine, OS, and Bash version from O(7-8min) down to the following at https://github.com/mbland/go-script-bash/commit/69ad67f8474522540c9f90d7fd4f93903aaa63ce:

```
  789 tests, 0 failures, 2 skipped

  real    2m57.196s
  user    1m30.371s
  sys     1m17.703s
```

Running again at the same commit, but using Bats with these changes included, the suite now runs in:

```
  real    1m24.217s
  user    1m1.195s
  sys     0m17.700s
```

### Performance impact on Windows

The impact is even more dramatic on Windows. On the same MacBook Pro, running Windows 10 under VMware Fusion 8.5.3 with 4GB RAM, and the timing for `./go test` before my changes to go-script-bash was in the O(50-60min) range for every version of Bash I have installed.  Afterwards, it was down in the O(20+min range).

Using Bats with these changes included, running the MSYS2-based Bash 4.3.46(2)-release that ships with (what is probably a slightly outdated version of) Git for Windows, the suite now runs in:

```
  real    6m20.981s
  user    1m53.852s
  sys     3m16.015s
```

Running Bash 4.4.11(2)-release running under Cygwin:

```
  real    5m22.506s
  user    1m34.462s
  sys     2m41.568s
```

And running Bash 4.3.11(1)-release as part of the Windows Subsystem for Linux (i.e. Ubuntu on Windows 10):

```
  real    3m40.502s
  user    0m36.531s
  sys     3m1.516s
```

### Other versions tested

In addition to the Bash versions mentioned above, I've also tested these changes using the following Bash versions:

- 4.2.25(1)-release: the version from the default Ubuntu 12.04.5/Precise image on Travis CI
- 4.3.42(1)-release: the latest on Alpine Linux
- 4.3.46(1)-release: the latest on Ubuntu 16.10
- 4.4.12(0)-release: the version from FreeBSD 10.3-RELEASE-p11
- 4.4.12(1)-release: the latest at the time of writing, on both Arch Linux and macOS via Homebrew

All of the go-script-bash tests passed on these other platforms in less than half the time from before. All of the Bats tests passed on every platform with the exception of a few on Alpine Linux; I can perhaps address these failures in the future.

### Future steps

There are other subshells that can likely be eliminated in other parts of Bats, particularly those that happen at startup when `bin/bats` is collecting information on the test suite, which introduces a bit of a startup pause proportional to the number of tests to run (especially noticeable on Windows). However, this seems like a good place to stop for now.
