### PR TITLE
Add matrix testing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: c
+
+matrix:
+    include:
+        - os: linux
+          dist: trusty
+          sudo: required
+        - os: linux
+        - os: osx
+
 script: bin/bats --tap test
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
This adds testing in travis for:

* Ubuntu Precise
* Ubuntu Trusty
* OSX

OSX tests are failing, I guess that's related to this #https://github.com/sstephenson/bats/issues/140 . Thus it can't be merged until OSX is fixed

Example results here: https://travis-ci.org/itsuugo/bats/builds/202207251