### PR TITLE
Add the arguments when calling the 'bats' script

### DIFF
--- a/bin/bats
+++ b/bin/bats
@@ -1,1 +1,1 @@
-../libexec/bats
+../libexec/bats $@


### PR DESCRIPTION
Fix for issue #203 - bats interpreter always shows usage.
I edited the bats script to supply the arguments to the 'bats' script in the 'libexec'.