### PR TITLE
Separate stdout and stderr from the run output

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -48,17 +48,25 @@ load() {
 }
 
 run() {
-  local e E T oldIFS
+  local e E T oldIFS 
   [[ ! "$-" =~ e ]] || e=1
   [[ ! "$-" =~ E ]] || E=1
   [[ ! "$-" =~ T ]] || T=1
   set +e
   set +E
   set +T
-  output="$("$@" 2>&1)"
-  status="$?"
+
+  eval "$({ t_sdterr=$({ t_stdout=$("$@"); t_ret=$?; } 2>&1; declare -p t_stdout  >&2; declare -pi t_ret >&2); declare -p t_sdterr; } 2>&1)"
+  
+  status=$t_ret
+  output="${t_stdout}${t_sdterr}"
+  stdout=$t_stdout
+  stderr=$t_sdterr
+
   oldIFS=$IFS
   IFS=$'\n' lines=($output)
+  IFS=$'\n' stdlines=($t_stdout)
+  IFS=$'\n' errlines=($t_sdterr)
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -262,3 +262,8 @@ fixtures bats
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 loop_func" ]
 }
+
+@test "testing stdout and stderr are separated" {
+  run bats "$FIXTURE_ROOT/stdout_stderr_separate.bats"
+  [ $status -eq 0 ]
+}

--- a/test/fixtures/bats/stdout_stderr_separate.bats
+++ b/test/fixtures/bats/stdout_stderr_separate.bats
@@ -1,0 +1,14 @@
+# see issue #89
+echo_std_err() {
+  echo "std output"
+  (>&2 echo "err output")
+  return 0
+}
+
+@test "std err" {
+  run echo_std_err
+  [ $status -eq 0 ]
+  [ "${stdout}" = "std output" ]
+  [ "${stderr}" = "err output" ]
+  [ "${output}" = "std outputerr output" ]
+}


### PR DESCRIPTION
Put all tested method output in the same variable is an alteration of the real method result. 
For exemple :

``` shell
testedMethod() {
  echo "the result"
  (>&2 echo "some log informations")
  return 0
}
value=$(testedMethod)
```
value contain only "the result" and when I use it in a script I'm only interested in "the result".
But it's not possible to assert only the stdout. It should be possible to assert separatly stdout and stderr.

That's why I propose this update.
In order to keep compatibility I juste add variables :

* **stdout**: Only the stdout output
* **stderr**: Only the stderr output
* **stdlines**: stdout by line
* **errlines**: stderr by line
* **output**: Contain stdout+stderr concatenated