### PR TITLE
Remove fancy syntax for bash 3.00 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: bin/bats --tap test
+script: bash --version && bin/bats --tap test
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: c
+install:
+  - wget https://ftp.gnu.org/gnu/bash/bash-3.0.16.tar.gz
+  - tar -xzvf bash-3.0.16.tar.gz
+  - pushd bash-3.0.16 && ./configure --prefix=/opt/bash-3.0.16 && make && sudo make install && popd
+  - export PATH=/opt/bash-3.0.16/bin:$PATH
 script: bash --version && bin/bats --tap test
 notifications:
   email:

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -9,7 +9,7 @@ encode_name() {
     name="${name//_/-5f}"
     name="${name//-/-2d}"
     name="${name// /_}"
-    result+="$name"
+    result="$result$name"
   else
     local length="${#name}"
     local char i
@@ -17,11 +17,11 @@ encode_name() {
     for ((i=0; i<length; i++)); do
       char="${name:$i:1}"
       if [ "$char" = " " ]; then
-        result+="_"
+        result="$result_"
       elif [[ "$char" =~ [[:alnum:]] ]]; then
-        result+="$char"
+        result="$result$char"
       else
-        result+="$(printf -- "-%02x" \'"$char")"
+        result="$result$(printf -- "-%02x" \'"$char")"
       fi
     done
   fi


### PR DESCRIPTION
Hello,
I tried to use BATS to test a script on a SunOS 10u9 server running a BASH 3.00.16(1)-release and I had issues with the `+=` syntax.
This commit changes this syntax to a plain concatenation that works with our old release. 