### PR TITLE
Fix call to ../libexec/bats from bin/bats when install/bin/bats is not current dir or parameters are passed

### DIFF
--- a/bin/bats
+++ b/bin/bats
@@ -1,1 +1,1 @@
-../libexec/bats
+$(dirname $0)/../libexec/bats "$@"


### PR DESCRIPTION
The following procedure failed:
 1. In "Git Bash" for windows.
 2. $ git clone https://github.com/sstephenson/bats.git
 3. $ ./bats/install.sh /usr/local

    Installed Bats to /usr/local/bin/bats

 4. $ bats mytest.bats

    /usr/local/bin/bats: line 1: ../libexec/bats: No such file or directory

Fixed by modifying bin/bats to be aware of $(dirname $0), and then I figured out that I also needed to pass parameters, hence "$@"