### PR TITLE
install.sh should make files executable before copy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,10 +28,11 @@ if [ -z "$1" ]; then
 fi
 
 BATS_ROOT="$(abs_dirname "$0")"
-mkdir -p "$PREFIX"/{bin,libexec,share/man/man{1,7}}
-cp -R "$BATS_ROOT"/bin/* "$PREFIX"/bin
-cp -R "$BATS_ROOT"/libexec/* "$PREFIX"/libexec
-cp "$BATS_ROOT"/man/bats.1 "$PREFIX"/share/man/man1
-cp "$BATS_ROOT"/man/bats.7 "$PREFIX"/share/man/man7
+mkdir -p "${PREFIX%/}"/{bin,libexec,share/man/man{1,7}}
+chmod +x "$BATS_ROOT"/bin/* "$BATS_ROOT"/libexec/*
+cp -R "$BATS_ROOT"/bin/* "${PREFIX%/}"/bin
+cp -R "$BATS_ROOT"/libexec/* "${PREFIX%/}"/libexec
+cp "$BATS_ROOT"/man/bats.1 "${PREFIX%/}"/share/man/man1
+cp "$BATS_ROOT"/man/bats.7 "${PREFIX%/}"/share/man/man7
 
-echo "Installed Bats to $PREFIX/bin/bats"
+echo "Installed Bats to ${PREFIX%/}/bin/bats"


### PR DESCRIPTION
I found I needed to do this in order to have executable scripts.