### PR TITLE
Update readme that this repository is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Bats: Bash Automated Testing System
 
+--------------------------------------------------------------------------------
+
+## :warning: Not Maintained
+
+This git repository is no longer maintained. The [Call for Maintainers](https://github.com/sstephenson/bats/issues/150)
+ resulted in an [Announcement](https://github.com/sstephenson/bats/issues/236)
+ that there was created a mirrored fork of Bats: https://github.com/bats-core/bats-core/ .
+
+  While this repository is not going to be deleted, pull requests and issues may be not handled anymore.
+
+--------------------------------------------------------------------------------
+
 Bats is a [TAP](http://testanything.org)-compliant testing framework
 for Bash. It provides a simple way to verify that the UNIX programs
 you write behave as expected.


### PR DESCRIPTION
Hi. In light of the latest events, I find it helpful if there was a note in Bats readme about BATS-core. I just would like to inform people who want to make Bats better and create new issues or PRs here, e.g. 
   * https://github.com/sstephenson/bats/issues/245
   * https://github.com/sstephenson/bats/pull/247
   * https://github.com/sstephenson/bats/pull/200

about BATS-core and I think writing that in each issue/PR not effective. 

You may merge this PR or treat it as a draft only but I think some information in readme or in git repo description is needed.

I also spotted this information: 
> If or when this repo is active again, it can optionally be integrated through git.

in [the announcement](https://github.com/sstephenson/bats/issues/236#issue-259319847) issue. You may want to attach it too.

And thank you @sstephenson for Bats, very much! I use it frequently and in many projects and while I haven't tried BATS-core yet, I like it that this test framework will be maintained again and improved.