### PR TITLE
Do not change the value of IFS; instead, use readarray

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -58,7 +58,7 @@ run() {
   output="$("$@" 2>&1)"
   status="$?"
   oldIFS=$IFS
-  IFS=$'\n' lines=($output)
+  readarray -t lines <<< "$output"
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T


### PR DESCRIPTION
Reassigning IFS breaks things like when the test suite then attempts to check if `[[ $output = "${list[*]}". See https://github.com/exercism/bash/issues/382